### PR TITLE
Fix Unicode names, line color config, and subsystem refresh timing

### DIFF
--- a/Compass_Plugin/compass/compass.cpp
+++ b/Compass_Plugin/compass/compass.cpp
@@ -1,4 +1,4 @@
-#include "compass.h"
+﻿#include "compass.h"
 #include "compass_textures.h"
 #include "plugin_helpers.h"
 #include "plugin_config.h"
@@ -59,6 +59,7 @@ namespace Compass
 		float    posY;
 		float    widthFraction;
 		int      entityScanInterval;
+		SDK::FLinearColor lineColor;
 		CompassConfig::EntitySettings    players;
 		CompassConfig::EntitySettings    cores;
 		CompassConfig::MarkerSettings    markers;
@@ -77,6 +78,8 @@ namespace Compass
 		s_cfg.posY                = CompassConfig::Config::GetPosY();
 		s_cfg.widthFraction       = CompassConfig::Config::GetWidthFraction();
 		s_cfg.entityScanInterval  = CompassConfig::Config::GetEntityScanInterval();
+		CompassConfig::Config::GetLineColor(
+			s_cfg.lineColor.R, s_cfg.lineColor.G, s_cfg.lineColor.B, s_cfg.lineColor.A);
 		s_cfg.players             = CompassConfig::Config::GetPlayers();
 		s_cfg.cores               = CompassConfig::Config::GetBaseCores();
 		s_cfg.markers             = CompassConfig::Config::GetMarkers();
@@ -153,6 +156,14 @@ namespace Compass
 		LOG_DEBUG("[Compass] Scan complete: %d players, %d cores, %d POIs (%d caves), %d bodies, %d drones, %d enemies, %d custompins",
 			(int)s_playerMarkers.size(), (int)s_cores.size(),
 			(int)s_markers.size(), caveCount, bodyCount, droneCount, (int)s_enemies.size(), (int)s_customPins.size());
+
+		// Signal the subsystem AFTER reading so the next gameplay tick (which runs
+		// before our next PostRender) sees the flag and refreshes its data in time
+		// for our next scan. Setting it before the reads would only affect the tick
+		// AFTER this frame anyway, making it equivalent but less clear in intent.
+		SDK::APlayerController* localPC = SDK::UGameplayStatics::GetPlayerController(world, 0);
+		if (localPC)
+			*(uint8_t*)((char*)localPC + 3816) = 1;
 	}
 
 	// ---------------------------------------------------------------------------
@@ -238,7 +249,10 @@ namespace Compass
 		static constexpr SDK::FLinearColor black1   { 0.0f, 0.0f,  0.0f, 1.0f };
 
 		// --- Horizontal compass line ---
-		hud->DrawLine(left, posY, right, posY, dimWhite, 1.5f * scale);
+		// DrawLine ignores alpha (uses FBatchedElements which has no translucent blend).
+		// DrawRect uses FCanvasTileItem with SE_BLEND_Translucent, so alpha works.
+		const float lineH = 1.5f * scale;
+		hud->DrawRect(s_cfg.lineColor, left, posY - lineH * 0.5f, right - left, lineH);
 
 		// --- Cardinal ticks + labels (above the line) ---
 		for (const auto& c : CARDINALS)
@@ -419,7 +433,7 @@ namespace Compass
 				const float alpha = DistAlpha(sqrtf(distSq), cfgPlayers.distance);
 				if (alpha <= 0.0f) continue;
 				const float sx = ToScreenX(p.location);
-				std::wstring wn(p.playerName.begin(), p.playerName.end());
+				const std::wstring wn = p.playerName;
 				drawQueue.push_back({ distSq, [=]{ DrawEntityIconWithLabel(sx, s_tex.player, wn.c_str(), colPlayer, alpha); } });
 			}
 		}
@@ -432,7 +446,7 @@ namespace Compass
 				const float alpha = DistAlpha(sqrtf(distSq), cfgCores.distance);
 				if (alpha <= 0.0f) continue;
 				const float sx = ToScreenX(c.location);
-				std::wstring wn(c.name.begin(), c.name.end());
+				const std::wstring wn = c.name;
 				drawQueue.push_back({ distSq, [=]{ DrawEntityIconWithLabel(sx, s_tex.baseCore, wn.c_str(), colCore, alpha); } });
 			}
 		}
@@ -488,9 +502,7 @@ namespace Compass
 					pin.color.R, pin.color.G, pin.color.B,
 					pin.color.A > 0.0f ? pin.color.A : 1.0f
 				};
-				std::wstring label = pin.playerName.empty()
-					? L"Pin"
-					: std::wstring(pin.playerName.begin(), pin.playerName.end());
+				const std::wstring label = pin.playerName.empty() ? L"Pin" : pin.playerName;
 				drawQueue.push_back({ distSq, [=]{ DrawEntityIconWithLabel(sx, s_tex.customPin, label.c_str(), col, alpha); } });
 			}
 		}

--- a/Compass_Plugin/layout/layout_basecores.h
+++ b/Compass_Plugin/layout/layout_basecores.h
@@ -15,7 +15,7 @@ struct BaseCoreEntry
 	SDK::uint8   upgradeLevel;
 	bool         bIsAttacked;
 	bool         bIsInfected;
-	std::string  name;
+	std::wstring name;
 };
 
 // Returns all ACrBaseCore actors in the level, with custom names resolved.
@@ -55,8 +55,10 @@ inline std::vector<BaseCoreEntry> ScanBaseCores(SDK::UWorld* world)
 		// 1. Player-set custom name
 		if (nameSys)
 		{
-			e.name = nameSys->GetBuildingCustomName(core).ToString();
-			LOG_TRACE("[Compass] ScanBaseCores[%d]: custom name = '%s'", i, e.name.c_str());
+			SDK::FString fs = nameSys->GetBuildingCustomName(core);
+			const wchar_t* p = fs.CStr();
+			e.name = (p && fs.Num() > 0) ? p : L"";
+			LOG_TRACE("[Compass] ScanBaseCores[%d]: custom name = '%ls'", i, e.name.c_str());
 		}
 
 		// 2. Interaction component display name
@@ -68,16 +70,20 @@ inline std::vector<BaseCoreEntry> ScanBaseCores(SDK::UWorld* world)
 			{
 				auto* ic = static_cast<SDK::UCrInteractionComponent*>(comps[j]);
 				if (!ic) continue;
-				e.name = ic->GetInteractionDisplayName().ToString();
+				{
+					SDK::FText ft = ic->GetInteractionDisplayName();
+					const wchar_t* p = ft.GetStringRef().CStr();
+					e.name = (p && ft.GetStringRef().Num() > 0) ? p : L"";
+				}
 				if (!e.name.empty()) break;
 			}
 		}
 
 		// 3. Hard fallback
 		if (e.name.empty())
-			e.name = "Base Core";
+			e.name = L"Base Core";
 
-		LOG_TRACE("[Compass] ScanBaseCores[%d]: '%s' at (%.0f, %.0f, %.0f)",
+		LOG_TRACE("[Compass] ScanBaseCores[%d]: '%ls' at (%.0f, %.0f, %.0f)",
 			i, e.name.c_str(), e.location.X, e.location.Y, e.location.Z);
 		result.push_back(e);
 	}
@@ -180,7 +186,7 @@ inline std::vector<BaseCoreEntry> ScanBaseCores(SDK::UWorld* world)
 
 		if (bmd.Num() > 0)
 		{
-			// Fresh data available — rebuild the distant-core cache
+			// Fresh data available -- rebuild the distant-core cache
 			s_distantCoreCache.clear();
 			for (int i = 0; i < bmd.Num(); i++)
 			{
@@ -197,24 +203,8 @@ inline std::vector<BaseCoreEntry> ScanBaseCores(SDK::UWorld* world)
 		}
 		else
 		{
-			LOG_TRACE("[ScanBaseCores] bmd is empty — UCrMapManuSubsystem may not have ticked yet, cache has %d entries",
+			LOG_TRACE("[ScanBaseCores] bmd is empty -- waiting for subsystem tick, cache has %d entries",
 				(int)s_distantCoreCache.size());
-
-			// UCrMapManuSubsystem::UpdateMapMenuData only calls GatherBuildingsData when
-			// byte+3816 on the local PC is non-zero (the "map is open" flag).
-			// Force it here so the subsystem populates BMD on its next tick.
-			SDK::APlayerController* localPC =
-				SDK::UGameplayStatics::GetPlayerController(world, 0);
-			LOG_TRACE("[ScanBaseCores] Forcing map-open flag: localPC=%p", (void*)localPC);
-			if (localPC)
-			{
-				*(uint8_t*)((char*)localPC + 3816) = 1;
-				LOG_TRACE("[ScanBaseCores] Set byte+3816=1 on localPC %p", (void*)localPC);
-			}
-			else
-			{
-				LOG_WARN("[ScanBaseCores] GetPlayerController(0) returned null — cannot force flag");
-			}
 		}
 	}
 	else
@@ -241,7 +231,7 @@ inline std::vector<BaseCoreEntry> ScanBaseCores(SDK::UWorld* world)
 		e.upgradeLevel = 0;
 		e.bIsAttacked  = false;
 		e.bIsInfected  = false;
-		e.name         = "Base Core";
+		e.name         = L"Base Core";
 		result.push_back(e);
 		++added;
 	}

--- a/Compass_Plugin/layout/layout_custompins.h
+++ b/Compass_Plugin/layout/layout_custompins.h
@@ -12,12 +12,12 @@ namespace Layout
 struct CustomPinEntry
 {
 	SDK::FVector      location;     // X,Y from FVector2f; Z set to 0
-	std::string       playerName;
+	std::wstring      playerName;
 	SDK::FLinearColor color;
 };
 
 // Returns all personal map markers from ACrGameStateBase::PlayerPersonalMarkers.
-// These are custom pins placed by any player — replicated to all clients via GameState.
+// These are custom pins placed by any player -- replicated to all clients via GameState.
 inline std::vector<CustomPinEntry> ScanCustomPins(SDK::UWorld* world)
 {
 	std::vector<CustomPinEntry> result;
@@ -38,11 +38,14 @@ inline std::vector<CustomPinEntry> ScanCustomPins(SDK::UWorld* world)
 		const auto& item = pins[i];
 
 		CustomPinEntry e;
-		e.location   = { item.MarkerPosition.X, item.MarkerPosition.Y, 0.0f };
-		e.playerName = item.PlayerName.ToString() + "'s Marker";
-		e.color      = item.PlayerColor;
+		e.location = { item.MarkerPosition.X, item.MarkerPosition.Y, 0.0f };
+		const wchar_t* p = item.PlayerName.CStr();
+		e.playerName = (p && item.PlayerName.Num() > 0)
+			? (std::wstring(p) + L"'s Marker")
+			: L"'s Marker";
+		e.color = item.PlayerColor;
 
-		LOG_TRACE("[ScanCustomPins] [%d] player='%s' loc=(%.0f,%.0f)",
+		LOG_TRACE("[ScanCustomPins] [%d] player='%ls' loc=(%.0f,%.0f)",
 			i, e.playerName.c_str(), e.location.X, e.location.Y);
 
 		result.push_back(e);

--- a/Compass_Plugin/layout/layout_hlod.h
+++ b/Compass_Plugin/layout/layout_hlod.h
@@ -113,7 +113,7 @@ inline void ScanHLOD(SDK::UWorld* world,
 				e.upgradeLevel = 0;
 				e.bIsAttacked  = false;
 				e.bIsInfected  = false;
-				e.name         = "Base Core";
+				e.name         = L"Base Core";
 				inOutCores.push_back(e);
 				hlodAdded++;
 				LOG_TRACE("[ScanHLOD] Added distant BaseCore (mesh='%s') at (%.0f,%.0f,%.0f)",

--- a/Compass_Plugin/layout/layout_playermarkers.h
+++ b/Compass_Plugin/layout/layout_playermarkers.h
@@ -12,7 +12,7 @@ namespace Layout
 struct PlayerMarkerEntry
 {
 	SDK::FVector  location;      // X,Y from FVector2f; Z set to 0
-	std::string   playerName;
+	std::wstring  playerName;
 	SDK::FLinearColor color;
 	float         rotationZ;
 	SDK::uint8    flags;         // EPlayerMarkerFlags
@@ -35,13 +35,17 @@ inline std::vector<PlayerMarkerEntry> ScanPlayerMarkers(SDK::UWorld* world)
 		return result;
 
 	// Resolve local player name so we can skip our own dot.
-	std::string localName;
+	std::wstring localName;
 	SDK::APlayerController* localPC = SDK::UGameplayStatics::GetPlayerController(world, 0);
 	if (localPC && localPC->PlayerState)
-		localName = localPC->PlayerState->PlayerNamePrivate.ToString();
+	{
+		const wchar_t* lp = localPC->PlayerState->PlayerNamePrivate.CStr();
+		if (lp && localPC->PlayerState->PlayerNamePrivate.Num() > 0)
+			localName = lp;
+	}
 
 	auto& data = mapHelper->PlayersMarkerDataContainer.PlayersMarkerData;
-	LOG_TRACE("[ScanPlayerMarkers] mapHelper=%p data.Num()=%d localName='%s'",
+	LOG_TRACE("[ScanPlayerMarkers] mapHelper=%p data.Num()=%d localName='%ls'",
 		(void*)mapHelper, data.Num(), localName.c_str());
 
 	for (int i = 0; i < data.Num(); i++)
@@ -49,20 +53,19 @@ inline std::vector<PlayerMarkerEntry> ScanPlayerMarkers(SDK::UWorld* world)
 		const auto& item = data[i];
 
 		PlayerMarkerEntry e;
-		std::string rawName = item.Player.ToString();
+		const wchar_t* p = item.Player.CStr();
+		e.playerName = (p && item.Player.Num() > 0) ? p : L"";
 
 		// Skip the local player - no need to show yourself.
-		if (!localName.empty() && rawName == localName)
+		if (!localName.empty() && e.playerName == localName)
 			continue;
-
-		e.playerName = rawName;
 
 		e.location   = { item.Location.X, item.Location.Y, 0.0f };
 		e.color      = item.PlayerColor;
 		e.rotationZ  = item.RotationZ;
 		e.flags      = static_cast<SDK::uint8>(item.PlayerMarkerFlags);
 
-		LOG_TRACE("[ScanPlayerMarkers] [%d] player='%s' loc=(%.0f,%.0f) flags=%d",
+		LOG_TRACE("[ScanPlayerMarkers] [%d] player='%ls' loc=(%.0f,%.0f) flags=%d",
 			i, e.playerName.c_str(), e.location.X, e.location.Y, (int)e.flags);
 
 		result.push_back(e);

--- a/Compass_Plugin/plugin_config.h
+++ b/Compass_Plugin/plugin_config.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "plugin_interface.h"
+#include <cstdio>
+#include <cstring>
 
 namespace CompassConfig
 {
@@ -10,10 +12,11 @@ namespace CompassConfig
 		{ "General", "TextOnly",                 ConfigValueType::Boolean, "false",   "Force text-only mode — never draw icon textures (useful for debugging)" },
 
 		// ----- Compass bar -----
-		{ "Compass", "Scale",                    ConfigValueType::Float,   "1.2",     "Compass size multiplier" },
-		{ "Compass", "PosY",                     ConfigValueType::Float,   "60.0",    "Pixels from top of screen to the compass line" },
-		{ "Compass", "WidthFraction",            ConfigValueType::Float,   "0.50",    "Half-width as fraction of screen width (0.20 = 40% total)" },
-		{ "Compass", "EntityScanInterval",       ConfigValueType::Integer, "90",      "Frames between entity scans (90 = ~1.5s at 60fps)" },
+		{ "Compass", "Scale",                    ConfigValueType::Float,   "1.2",              "Compass size multiplier" },
+		{ "Compass", "PosY",                     ConfigValueType::Float,   "60.0",             "Pixels from top of screen to the compass line" },
+		{ "Compass", "WidthFraction",            ConfigValueType::Float,   "0.50",             "Half-width as fraction of screen width (0.20 = 40% total)" },
+		{ "Compass", "EntityScanInterval",       ConfigValueType::Integer, "90",               "Frames between entity scans (90 = ~1.5s at 60fps)" },
+		{ "Compass", "LineColor",                ConfigValueType::String,  "1.0, 1.0, 1.0, 0.4", "Horizontal bar colour as R, G, B, A (each 0.0-1.0). Invalid input uses the default." },
 
 		// ----- Players -----
 		{ "Players", "Enabled",                  ConfigValueType::Boolean, "true",    "Show other player markers on the compass" },
@@ -122,6 +125,32 @@ namespace CompassConfig
 		static int GetEntityScanInterval()
 		{
 			return s_config ? s_config->ReadInt("Compass", "Compass", "EntityScanInterval", 90) : 90;
+		}
+
+		// Returns the horizontal bar colour from config, or the default {1,1,1,0.4} on any
+		// parse error or out-of-range component. Format: "R, G, B, A" (each 0.0-1.0).
+		static void GetLineColor(float& r, float& g, float& b, float& a)
+		{
+			// Defaults
+			r = 1.0f; g = 1.0f; b = 1.0f; a = 0.4f;
+
+			if (!s_config) return;
+
+			char buf[64] = {};
+			if (!s_config->ReadString("Compass", "Compass", "LineColor", buf, (int)sizeof(buf), ""))
+				return;
+
+			float tr, tg, tb, ta;
+			// Accept "R, G, B, A" or "R,G,B,A" (with or without spaces)
+			if (sscanf_s(buf, "%f , %f , %f , %f", &tr, &tg, &tb, &ta) != 4)
+				return;
+
+			// All components must be in [0, 1]
+			if (tr < 0.0f || tr > 1.0f || tg < 0.0f || tg > 1.0f ||
+				tb < 0.0f || tb > 1.0f || ta < 0.0f || ta > 1.0f)
+				return;
+
+			r = tr; g = tg; b = tb; a = ta;
 		}
 
 		// ----- Entity settings -----


### PR DESCRIPTION
- Store entity names as std::wstring and populate via FString::CStr() instead of the ToString() -> std::string -> std::wstring round-trip which corrupted non-ASCII characters
- Add Compass.LineColor config (R, G, B, A) for the compass bar; invalid input silently falls back to default. Switch DrawLine to DrawRect so alpha is respected (DrawLine ignores alpha)
- Move byte+3816 poke to end of RefreshEntities so the subsystem refreshes on the next gameplay tick rather than the same frame; centralises the poke so all scanners benefit (fixes looted bodies lingering on the compass until the map is opened)