### PR TITLE
Revert "Guard ImGui init when Steam overlay + Streamline"

### DIFF
--- a/Version_Mod_Loader/UI/imgui_backend.cpp
+++ b/Version_Mod_Loader/UI/imgui_backend.cpp
@@ -1089,14 +1089,6 @@ namespace UI::ImGuiBackend
 			if (rtss)
 				LogToFile::Info("[ImGuiBackend] RTSS (RivaTuner/Afterburner) detected -- "
 					"if the overlay crashes, disable RTSS and report the issue");
-
-			if (steam && g_streamlineActive)
-			{
-				LogToFile::Warn("[ImGuiBackend] Streamline + Steam overlay detected -- "
-					"skipping ImGui initialization to avoid Present recursion. "
-					"Disable Steam overlay or DLSS Frame Generation to re-enable the UI.");
-				return;
-			}
 		}
 
 		// Log system diagnostics so crash reports have full hardware/OS context.


### PR DESCRIPTION
Reverts AlienXAXS/StarRupture-ModLoader#59

Going to revert this, A lot of people use DLSS + Steam overlay and do not crash.
I rather not completely disable ImGui for everyone who its working for.  If you are crashing with DLSS+Steam Overlay, contact me on the SR Discord and we can possibly fix it.