### PR TITLE
fix network channel server initialization

### DIFF
--- a/Version_Mod_Loader/dllmain.cpp
+++ b/Version_Mod_Loader/dllmain.cpp
@@ -24,6 +24,7 @@
 #include "hooks/game/mass_spawner_activate/mass_spawner_activate.h"
 #include "hooks/game/mass_spawner_deactivate/mass_spawner_deactivate.h"
 #include "hooks/game/mass_do_spawning/mass_do_spawning.h"
+#include "network_channel/network_channel.h"
 #include "hooks/game/game_instance_init/game_instance_init.h"
 
 #include "auto_update/auto_updater.h"
@@ -495,6 +496,16 @@ static DWORD WINAPI MainInitThreadProc(LPVOID)
 
 	ModLoaderLogger::LoadAllPlugins();
 
+	// Bug fix: if the GameInstanceInit one-shot latch fired before plugins
+	// were loaded (server startup race / 120s timeout scenario), plugins
+	// were left in "deferred" state and PluginInit was never called.
+	// Detect this and call InitAllLoadedPlugins now that the DLLs are loaded.
+	if (Hooks::GameInstanceInit::HasFired())
+	{
+		ModLoaderLogger::LogInfo(L"[dllmain] GameInstanceInit already fired before plugins loaded -- calling InitAllLoadedPlugins now");
+		ModLoaderLogger::InitAllLoadedPlugins();
+	}
+
 	Splash::SetStatus(L"Plugin DLLs loaded -- waiting for game instance...");
 	Splash::SetProgress(1.0f);
 
@@ -776,6 +787,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 
 		// Now safe to unload plugins
 		ModLoaderLogger::UnloadAllPlugins();
+		NetworkChannel::Shutdown();
 
 		// Remove remaining core game hooks
 		ModLoaderLogger::LogInfo(L"Removing remaining core game hooks...");

--- a/Version_Mod_Loader/hooks/game/server_chat_commit/server_chat_commit.cpp
+++ b/Version_Mod_Loader/hooks/game/server_chat_commit/server_chat_commit.cpp
@@ -5,6 +5,7 @@
 #include "network_channel/network_channel.h"
 #include "logging/logger.h"
 #include "CoreUObject_classes.hpp"
+#include "hooks/game/game_instance_init/game_instance_init.h"
 #include <hooks/hooks_common.h>
 
 // ---------------------------------------------------------------------------
@@ -44,36 +45,107 @@ namespace Hooks::ServerChatCommit
     static ExecFunc_t      g_origExec           = nullptr;
     static SDK::UFunction* g_serverExecCmdFunc   = nullptr;
 
+    struct FStringView { wchar_t* Data; int32_t Num; int32_t Max; };
+
+    static bool TryDispatchEnvelope(void* senderContext, FStringView* cmd, bool allowNeuter)
+    {
+        if (!cmd || !cmd->Data || cmd->Num < kModPrefixChars + 1)
+            return false;
+
+        ModLoaderLogger::LogTrace(
+            L"[ServerChatCommit] Command candidate data=%p num=%d max=%d sender=%p",
+            cmd->Data,
+            cmd->Num,
+            cmd->Max,
+            senderContext);
+
+        if (wcsncmp(cmd->Data, kModPrefix, kModPrefixChars) != 0)
+            return false;
+
+        bool consumed = NetworkChannel::DispatchServerMessage(senderContext, cmd->Data, cmd->Num);
+        if (!consumed)
+        {
+            ModLoaderLogger::LogWarn(
+                L"[ServerChatCommit] DispatchServerMessage returned false for context=%p",
+                senderContext);
+        }
+
+        if (allowNeuter)
+        {
+            // Prevent the original handler from logging "Command not recognized"
+            // when we already identified the payload as mod-loader traffic.
+            cmd->Data[0] = L'\0';
+            cmd->Num = 1;
+        }
+
+        return consumed;
+    }
+
+    static void ProcessEventObserver(void* obj, void* fn, void* params)
+    {
+        if (fn != g_serverExecCmdFunc || !params)
+            return;
+
+        auto* cmd = reinterpret_cast<FStringView*>(params);
+        if (TryDispatchEnvelope(obj, cmd, true))
+        {
+            ModLoaderLogger::LogTrace(
+                L"[ServerChatCommit] ProcessEvent observer consumed mod envelope for context=%p",
+                obj);
+        }
+    }
+
     static void __fastcall ExecHook(void* context, void* stack, void* result)
     {
+        ModLoaderLogger::LogTrace(
+            L"[ServerChatCommit] ExecHook enter context=%p stack=%p result=%p orig=%p",
+            context,
+            stack,
+            result,
+            reinterpret_cast<void*>(g_origExec));
+
         void* locals = *reinterpret_cast<void**>(static_cast<uint8_t*>(stack) + kFFrameLocalsOffset);
+        ModLoaderLogger::LogTrace(L"[ServerChatCommit] ExecHook locals=%p", locals);
 
         if (locals)
         {
-            struct FStringView { wchar_t* Data; int32_t Num; int32_t Max; };
             auto* cmd = reinterpret_cast<FStringView*>(locals);
 
-            if (cmd->Data && cmd->Num >= kModPrefixChars + 1 &&
-                wcsncmp(cmd->Data, kModPrefix, kModPrefixChars) == 0)
+            if (TryDispatchEnvelope(context, cmd, false))
             {
-                ModLoaderLogger::LogInfo(
-                    L"[ServerChatCommit] Mod envelope received from context=%p Num=%d",
-                    context, cmd->Num);
-
-                // context is the APlayerController that sent the RPC
-                bool consumed = NetworkChannel::DispatchServerMessage(context, cmd->Data, cmd->Num);
-                if (consumed)
-                    return; // suppress original -- don't execute as a console command
+                return; // suppress original -- don't execute as a console command
             }
+        }
+        else
+        {
+            auto* node = *reinterpret_cast<void**>(static_cast<uint8_t*>(stack) + 0x08);
+            auto* object = *reinterpret_cast<void**>(static_cast<uint8_t*>(stack) + 0x10);
+            auto* code = *reinterpret_cast<void**>(static_cast<uint8_t*>(stack) + 0x18);
+            ModLoaderLogger::LogTrace(
+                L"[ServerChatCommit] ExecHook has null locals; node=%p object=%p code=%p -- forwarding to original ExecFunction",
+                node,
+                object,
+                code);
         }
 
         if (g_origExec)
+        {
+            ModLoaderLogger::LogTrace(L"[ServerChatCommit] Calling original ExecFunction for context=%p", context);
             g_origExec(context, stack, result);
+        }
+        else
+        {
+            ModLoaderLogger::LogError(L"[ServerChatCommit] Original ExecFunction pointer is null during ExecHook");
+        }
     }
 
     bool Install()
     {
-        if (g_hook.installed) return true;
+        if (g_hook.installed)
+        {
+            ModLoaderLogger::LogInfo(L"[ServerChatCommit] Install skipped; hook already installed");
+            return true;
+        }
 
         g_serverExecCmdFunc = SDK::UObject::FindObjectFast<SDK::UFunction>(
             "ServerExecuteConsoleCommand", SDK::EClassCastFlags::Function);
@@ -109,11 +181,18 @@ namespace Hooks::ServerChatCommit
         else
             ModLoaderLogger::LogError(L"[ServerChatCommit] ExecFunction hook installation failed");
 
+        Hooks::GameInstanceInit::RegisterProcessEventCallback(&ProcessEventObserver);
+        ModLoaderLogger::LogInfo(L"[ServerChatCommit] ProcessEvent observer registered");
+
         return ok;
     }
 
     void Remove()
     {
+        Hooks::GameInstanceInit::UnregisterProcessEventCallback(&ProcessEventObserver);
+        ModLoaderLogger::LogInfo(
+            L"[ServerChatCommit] Removing ExecFunction hook (installed=%s)",
+            g_hook.installed ? L"true" : L"false");
         g_hook.Remove();
         g_origExec         = nullptr;
         g_serverExecCmdFunc = nullptr;

--- a/Version_Mod_Loader/hooks/hooks_interface.cpp
+++ b/Version_Mod_Loader/hooks/hooks_interface.cpp
@@ -828,13 +828,21 @@ namespace ModLoaderLogger
 #endif
 		nullptr          // v17 -- Network; filled in below by GetPluginHooks()
 	};
+	static bool g_networkChannelInitialized = false;
 
 	IPluginHooks* GetPluginHooks()
 	{
 		// Resolve the network channel pointer on first call.
 		// NetworkChannel::GetInterface() returns nullptr on generic builds.
 		if (!g_pluginHooks.Network)
+		{
 			g_pluginHooks.Network = NetworkChannel::GetInterface();
+			if (g_pluginHooks.Network && !g_networkChannelInitialized)
+			{
+				NetworkChannel::Initialize();
+				g_networkChannelInitialized = true;
+			}
+		}
 		return &g_pluginHooks;
 	}
 }

--- a/Version_Mod_Loader/network_channel/network_channel.cpp
+++ b/Version_Mod_Loader/network_channel/network_channel.cpp
@@ -125,6 +125,13 @@ namespace
         env += szSize;
         env += ":]";
         env += b64;
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] BuildEnvelope: plugin='%S' tag='%S' payload=%zu bytes base64=%zu chars total=%zu chars",
+            pluginName,
+            typeTag,
+            size,
+            b64.size(),
+            env.size());
         return env;
     }
 
@@ -133,6 +140,9 @@ namespace
         std::string pluginName;
         std::string typeTag;
         std::vector<uint8_t> payload;
+        size_t declaredSize = 0;
+        size_t encodedPayloadChars = 0;
+        const char* failureReason = "not_parsed";
         bool valid = false;
     };
 
@@ -140,7 +150,9 @@ namespace
     ParsedEnvelope ParseEnvelope(const char* str, size_t len)
     {
         ParsedEnvelope result;
+        result.failureReason = "too_short";
         if (len < kEnvPrefixLen + 4) return result;
+        result.failureReason = "missing_prefix";
         if (memcmp(str, kEnvPrefix, kEnvPrefixLen) != 0) return result;
 
         const char* p = str + kEnvPrefixLen;
@@ -148,30 +160,46 @@ namespace
 
         // pluginName
         const char* colon1 = static_cast<const char*>(memchr(p, ':', end - p));
+        result.failureReason = "missing_plugin_separator";
         if (!colon1) return result;
         result.pluginName.assign(p, colon1);
 
-        // typeTag
+        // The type tag may itself contain ':' (e.g. MSVC typeid names with namespaces).
+        // Parse from the end by locating the final ":]" marker that terminates the size field,
+        // then use the previous ':' as the typeTag/size separator.
+        const char* close = nullptr;
+        for (const char* scan = end - 1; scan > colon1 + 1; --scan)
+        {
+            if (*scan == ']' && *(scan - 1) == ':')
+            {
+                close = scan;
+                break;
+            }
+        }
+        result.failureReason = "missing_closing_bracket";
+        if (!close) return result;
+
+        const char* sizeColon = close - 1;
+        const char* typeColon = sizeColon - 1;
+        while (typeColon > colon1 && *typeColon != ':')
+            --typeColon;
+        result.failureReason = "missing_typetag_separator";
+        if (typeColon <= colon1 || *typeColon != ':') return result;
+
         p = colon1 + 1;
-        const char* colon2 = static_cast<const char*>(memchr(p, ':', end - p));
-        if (!colon2) return result;
-        result.typeTag.assign(p, colon2);
+        result.typeTag.assign(p, typeColon);
 
-        // size
-        p = colon2 + 1;
-        const char* colonBracket = static_cast<const char*>(memchr(p, ':', end - p));
-        if (!colonBracket) return result;
-        size_t declaredSize = static_cast<size_t>(atoi(p));
+        const char* sizeStart = typeColon + 1;
+        result.declaredSize = static_cast<size_t>(atoi(sizeStart));
 
-        // check for ":]"
-        p = colonBracket + 1;
-        if (p >= end || *p != ']') return result;
-        p++; // skip ']'
-
-        // base64 payload
+        // base64 payload starts right after the closing ']'
+        p = close + 1;
+        result.encodedPayloadChars = static_cast<size_t>(end - p);
         result.payload = Base64Decode(p, static_cast<size_t>(end - p));
-        if (result.payload.size() != declaredSize) return result;
+        result.failureReason = "payload_size_mismatch";
+        if (result.payload.size() != result.declaredSize) return result;
 
+        result.failureReason = nullptr;
         result.valid = true;
         return result;
     }
@@ -265,7 +293,7 @@ namespace
             return;
         }
 
-        ModLoaderLogger::LogDebug(L"[NetworkChannel] SendEnvelope: PC=%p func=%p flags=0x%08X envelope=%zu bytes",
+        ModLoaderLogger::LogTrace(L"[NetworkChannel] SendEnvelope: PC=%p func=%p flags=0x%08X envelope=%zu bytes",
                                   playerController, static_cast<void*>(g_clientSaveTxtFunc),
                                   g_clientSaveTxtFunc->FunctionFlags, envelope.size());
 
@@ -286,7 +314,7 @@ namespace
         auto* obj = reinterpret_cast<SDK::UObject*>(playerController);
         CallProcessEventSEH(obj, g_clientSaveTxtFunc, &parms);
 
-        ModLoaderLogger::LogDebug(L"[NetworkChannel] SendEnvelope: ProcessEvent returned");
+        ModLoaderLogger::LogTrace(L"[NetworkChannel] SendEnvelope: ProcessEvent returned");
     }
 
     // Server-side handler registry for Client->Server messages
@@ -296,11 +324,19 @@ namespace
     // IPluginNetworkChannel function implementations -- server build
 
     static bool NC_IsServer() { return true; }
+    static bool IsExcluded(void* playerController);
 
     static void NC_SendPacketToClient(void* playerController, const IPluginSelf* self,
                                       const char* typeTag, const uint8_t* data, size_t size)
     {
         if (!playerController || !self || !self->name || !typeTag || !data || size == 0) return;
+
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToClient: player=%p plugin='%S' tag='%S' payload=%zu bytes",
+            playerController,
+            self->name,
+            typeTag,
+            size);
 
         if (size > 1400)
         {
@@ -317,6 +353,12 @@ namespace
                                           const uint8_t* data, size_t size)
     {
         if (!self || !self->name || !typeTag || !data || size == 0) return;
+
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToAllClients: plugin='%S' tag='%S' payload=%zu bytes",
+            self->name,
+            typeTag,
+            size);
 
         if (size > 1400)
         {
@@ -340,9 +382,20 @@ namespace
             SDK::ACrPlayerControllerBase::StaticClass(),
             &actors);
 
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToAllClients: found %d player controllers",
+            actors.Num());
+
         for (int32_t i = 0; i < actors.Num(); ++i)
         {
-        	SendEnvelopeToPlayer(actors[i], env);
+	        if (IsExcluded(actors[i]))
+	        {
+	            ModLoaderLogger::LogTrace(
+	                L"[NetworkChannel] SendPacketToAllClients: skipping excluded controller %p",
+	                actors[i]);
+	            continue;
+	        }
+	        SendEnvelopeToPlayer(actors[i], env);
         }
     }
 
@@ -370,6 +423,11 @@ namespace
         {
             std::lock_guard<std::mutex> lk(g_serverMutex);
             g_serverHandlers[key].push_back(callback);
+            ModLoaderLogger::LogDebug(
+                L"[NetworkChannel] Server handler count for plugin='%S' tag='%S' is now %zu",
+                self->name,
+                typeTag,
+                g_serverHandlers[key].size());
         }
         ModLoaderLogger::LogDebug(
             L"[NetworkChannel] Server handler registered for plugin='%S' tag='%S'",
@@ -387,6 +445,11 @@ namespace
         {
             auto& vec = it->second;
             vec.erase(std::remove(vec.begin(), vec.end(), callback), vec.end());
+            ModLoaderLogger::LogDebug(
+                L"[NetworkChannel] Server handler count for plugin='%S' tag='%S' after unregister is %zu",
+                self->name,
+                typeTag,
+                vec.size());
             if (vec.empty())
                 g_serverHandlers.erase(it);
         }
@@ -481,8 +544,13 @@ namespace
         {
             std::lock_guard<std::mutex> lk(g_mutex);
             g_handlers[key].push_back(callback);
+            ModLoaderLogger::LogTrace(
+                L"[NetworkChannel] Client handler count for plugin='%S' tag='%S' is now %zu",
+                self->name,
+                typeTag,
+                g_handlers[key].size());
         }
-        ModLoaderLogger::LogDebug(L"[NetworkChannel] Handler registered for plugin='%S' tag='%S'",
+        ModLoaderLogger::LogTrace(L"[NetworkChannel] Handler registered for plugin='%S' tag='%S'",
                                   self->name, typeTag);
         // Install the ProcessEvent hook lazily on first registration
         if (!Hooks::ClientMessage::IsInstalled())
@@ -513,6 +581,12 @@ namespace
     {
         if (!self || !self->name || !typeTag || !data || size == 0) return;
 
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToServer: plugin='%S' tag='%S' payload=%zu bytes",
+            self->name,
+            typeTag,
+            size);
+
         if (size > 1400)
         {
             ModLoaderLogger::LogWarn(
@@ -542,6 +616,12 @@ namespace
         }
 
         std::string env = BuildEnvelope(self->name, typeTag, data, size);
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToServer: localPC=%p func=%p flags=0x%08X envelope=%zu chars",
+            localPC,
+            static_cast<void*>(g_serverExecCmdFunc),
+            g_serverExecCmdFunc ? g_serverExecCmdFunc->FunctionFlags : 0u,
+            env.size());
 
         // Convert to wide for FString
         int wlen = MultiByteToWideChar(CP_UTF8, 0, env.c_str(), -1, nullptr, 0);
@@ -556,6 +636,10 @@ namespace
 
         auto* obj = reinterpret_cast<SDK::UObject*>(localPC);
         CallProcessEventSEH(obj, g_serverExecCmdFunc, &parms);
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] SendPacketToServer: ProcessEvent returned for plugin='%S' tag='%S'",
+            self->name,
+            typeTag);
     }
 
     // Client->Server receive handlers are server-only; these are no-ops on client
@@ -602,17 +686,49 @@ namespace
 #ifdef MODLOADER_CLIENT_BUILD
 void NetworkChannel::DispatchClientMessage(const wchar_t* str, int numCharsWithNull)
 {
-    if (!str || numCharsWithNull <= static_cast<int>(kEnvPrefixLen)) return;
+    if (!str)
+    {
+        ModLoaderLogger::LogTrace(L"[NetworkChannel] DispatchClientMessage: null string");
+        return;
+    }
+    if (numCharsWithNull <= static_cast<int>(kEnvPrefixLen))
+    {
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] DispatchClientMessage: string too short (%d chars incl null)",
+            numCharsWithNull);
+        return;
+    }
 
     // Convert wide string to narrow for envelope parsing
     int nbytes = WideCharToMultiByte(CP_UTF8, 0, str, numCharsWithNull - 1, nullptr, 0, nullptr, nullptr);
-    if (nbytes <= 0) return;
+    if (nbytes <= 0)
+    {
+        ModLoaderLogger::LogWarn(
+            L"[NetworkChannel] DispatchClientMessage: WideCharToMultiByte failed for %d chars",
+            numCharsWithNull);
+        return;
+    }
 
     std::string narrow(static_cast<size_t>(nbytes), '\0');
     WideCharToMultiByte(CP_UTF8, 0, str, numCharsWithNull - 1, narrow.data(), nbytes, nullptr, nullptr);
 
     ParsedEnvelope env = ParseEnvelope(narrow.c_str(), static_cast<size_t>(nbytes));
-    if (!env.valid) return;
+    if (!env.valid)
+    {
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] DispatchClientMessage: invalid envelope reason='%S' input=%d bytes",
+            env.failureReason ? env.failureReason : "unknown",
+            nbytes);
+        return;
+    }
+
+    ModLoaderLogger::LogTrace(
+        L"[NetworkChannel] DispatchClientMessage: parsed plugin='%S' tag='%S' declared=%zu decoded=%zu base64=%zu",
+        env.pluginName.c_str(),
+        env.typeTag.c_str(),
+        env.declaredSize,
+        env.payload.size(),
+        env.encodedPayloadChars);
 
     // Dispatch to registered handlers
     std::string key = MakeHandlerKey(env.pluginName.c_str(), env.typeTag.c_str());
@@ -621,9 +737,22 @@ void NetworkChannel::DispatchClientMessage(const wchar_t* str, int numCharsWithN
     {
         std::lock_guard<std::mutex> lk(g_mutex);
         auto it = g_handlers.find(key);
-        if (it == g_handlers.end()) return;
+        if (it == g_handlers.end())
+        {
+            ModLoaderLogger::LogTrace(
+                L"[NetworkChannel] DispatchClientMessage: no handler for plugin='%S' tag='%S'",
+                env.pluginName.c_str(),
+                env.typeTag.c_str());
+            return;
+        }
         callbacks = it->second; // copy snapshot
     }
+
+    ModLoaderLogger::LogTrace(
+        L"[NetworkChannel] DispatchClientMessage: dispatching to %zu handler(s) for plugin='%S' tag='%S'",
+        callbacks.size(),
+        env.pluginName.c_str(),
+        env.typeTag.c_str());
 
     for (auto* cb : callbacks)
     {
@@ -658,17 +787,53 @@ void NetworkChannel::DispatchClientMessage(const wchar_t* str, int numCharsWithN
 #ifdef MODLOADER_SERVER_BUILD
 bool NetworkChannel::DispatchServerMessage(void* senderUObject, const wchar_t* str, int numCharsWithNull)
 {
-    if (!str || numCharsWithNull <= static_cast<int>(kEnvPrefixLen)) return false;
+    if (!str)
+    {
+        ModLoaderLogger::LogTrace(L"[NetworkChannel] DispatchServerMessage: null string from sender=%p", senderUObject);
+        return false;
+    }
+    if (numCharsWithNull <= static_cast<int>(kEnvPrefixLen))
+    {
+        ModLoaderLogger::LogTrace(
+            L"[NetworkChannel] DispatchServerMessage: string too short (%d chars incl null) from sender=%p",
+            numCharsWithNull,
+            senderUObject);
+        return false;
+    }
 
     // Convert wide string to narrow for envelope parsing
     int nbytes = WideCharToMultiByte(CP_UTF8, 0, str, numCharsWithNull - 1, nullptr, 0, nullptr, nullptr);
-    if (nbytes <= 0) return false;
+    if (nbytes <= 0)
+    {
+        ModLoaderLogger::LogWarn(
+            L"[NetworkChannel] DispatchServerMessage: WideCharToMultiByte failed for sender=%p chars=%d",
+            senderUObject,
+            numCharsWithNull);
+        return false;
+    }
 
     std::string narrow(static_cast<size_t>(nbytes), '\0');
     WideCharToMultiByte(CP_UTF8, 0, str, numCharsWithNull - 1, narrow.data(), nbytes, nullptr, nullptr);
 
     ParsedEnvelope env = ParseEnvelope(narrow.c_str(), static_cast<size_t>(nbytes));
-    if (!env.valid) return false;
+    if (!env.valid)
+    {
+        ModLoaderLogger::LogWarn(
+            L"[NetworkChannel] DispatchServerMessage: invalid envelope from sender=%p reason='%S' input=%d bytes",
+            senderUObject,
+            env.failureReason ? env.failureReason : "unknown",
+            nbytes);
+        return false;
+    }
+
+    ModLoaderLogger::LogTrace(
+        L"[NetworkChannel] DispatchServerMessage: parsed sender=%p plugin='%S' tag='%S' declared=%zu decoded=%zu base64=%zu",
+        senderUObject,
+        env.pluginName.c_str(),
+        env.typeTag.c_str(),
+        env.declaredSize,
+        env.payload.size(),
+        env.encodedPayloadChars);
 
     // Dispatch to registered server-side handlers
     std::string key = MakeHandlerKey(env.pluginName.c_str(), env.typeTag.c_str());
@@ -677,9 +842,23 @@ bool NetworkChannel::DispatchServerMessage(void* senderUObject, const wchar_t* s
     {
         std::lock_guard<std::mutex> lk(g_serverMutex);
         auto it = g_serverHandlers.find(key);
-        if (it == g_serverHandlers.end()) return true; // valid envelope but no handler -- still consumed
+        if (it == g_serverHandlers.end())
+        {
+            ModLoaderLogger::LogWarn(
+                L"[NetworkChannel] DispatchServerMessage: no server handler for plugin='%S' tag='%S' sender=%p",
+                env.pluginName.c_str(),
+                env.typeTag.c_str(),
+                senderUObject);
+            return true; // valid envelope but no handler -- still consumed
+        }
         callbacks = it->second; // copy snapshot
     }
+
+    ModLoaderLogger::LogTrace(
+        L"[NetworkChannel] DispatchServerMessage: dispatching to %zu server handler(s) for plugin='%S' tag='%S'",
+        callbacks.size(),
+        env.pluginName.c_str(),
+        env.typeTag.c_str());
 
     for (auto* cb : callbacks)
     {


### PR DESCRIPTION
## Summary

* Initialize the mod loader network channel when plugin hooks are first exposed so the server receive hooks are actually installed
* Fix client-to-server envelope parsing for MSVC type tags containing `::`
* Add a server-side fallback path for `ServerExecuteConsoleCommand` handling and clean up noisy network logs

## Why

* Dedicated server requests sent through `IPluginNetworkChannel` reached the server as `[MOD:...]` envelopes but were not consumed by the mod loader
* On the server, this fell through to normal console command handling and produced `Command not recognized` instead of dispatching the packet to the plugin handler

Root causes:

* The network channel backend was exposed through `hooks->Network` but never initialized
* The server receive path required a safer fallback when the expected `ExecFunction` stack locals were missing
* The envelope parser incorrectly split MSVC `typeid` names containing `::`
