### PR TITLE
Fix/server plugin init race

### DIFF
--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -153,7 +153,8 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <GameDeployDir>F:\starrupture\server\StarRupture\Binaries\Win64\</GameDeployDir>
+    <!-- GameDeployDir is defined per-machine in Version_Mod_Loader.vcxproj.user (gitignored). -->
+    <!-- Set it there to enable automatic deploy after build. -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>dwmapi</TargetName>
@@ -216,6 +217,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -223,14 +225,7 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -255,14 +250,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Client Debug|x64'">
     <ClCompile>
@@ -275,6 +263,7 @@ echo Deploy complete.</Command>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)imgui;$(StarRuptureSDKConfigDir);$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -312,14 +301,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Server Debug|x64'">
     <ClCompile>
@@ -332,6 +314,7 @@ echo Deploy complete.</Command>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(StarRuptureSDKConfigDir);$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -339,14 +322,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Server Release|x64'">
     <ClCompile>
@@ -371,14 +347,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Client Debug|x64'">
     <ClCompile>
@@ -391,6 +360,7 @@ echo Deploy complete.</Command>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)imgui;$(StarRuptureSDKConfigDir);$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -428,14 +398,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Server Debug|x64'">
     <ClCompile>
@@ -448,6 +411,7 @@ echo Deploy complete.</Command>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(StarRuptureSDKConfigDir);$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -455,14 +419,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Server Release|x64'">
     <ClCompile>
@@ -487,14 +444,7 @@ echo Deploy complete.</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-    <PostBuildEvent>
-      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
-if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
-copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
-if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
-echo Deploy complete.</Command>
-      <Message>Copying dwmapi.dll to game server directory...</Message>
-    </PostBuildEvent>
+
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="auto_update\auto_updater.h" />

--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -153,8 +153,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <!-- GameDeployDir is defined per-machine in Version_Mod_Loader.vcxproj.user (gitignored). -->
-    <!-- Set it there to enable automatic deploy after build. -->
+    <GameDeployDir>F:\starrupture\server\StarRupture\Binaries\Win64\</GameDeployDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>dwmapi</TargetName>
@@ -217,7 +216,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>None</DebugInformationFormat>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -225,7 +223,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -250,7 +255,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Client Debug|x64'">
     <ClCompile>
@@ -263,7 +275,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)imgui;$(StarRuptureSDKConfigDir);$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -301,7 +312,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Server Debug|x64'">
     <ClCompile>
@@ -314,7 +332,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(StarRuptureSDKConfigDir);$(SolutionDir)StarRupture SDK\Server\;$(SolutionDir)StarRupture SDK\Server\SDK;$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -322,7 +339,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Server Release|x64'">
     <ClCompile>
@@ -347,7 +371,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Client Debug|x64'">
     <ClCompile>
@@ -360,7 +391,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)imgui;$(StarRuptureSDKConfigDir);$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -398,7 +428,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Server Debug|x64'">
     <ClCompile>
@@ -411,7 +448,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(StarRuptureSDKConfigDir);$(ProjectDir);$(SolutionDir)src;$(SolutionDir)Version_Mod_Loader;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -419,7 +455,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Local SDK Server Release|x64'">
     <ClCompile>
@@ -444,7 +487,14 @@
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>$(ProjectDir)dwmapi.def</ModuleDefinitionFile>
     </Link>
-
+    <PostBuildEvent>
+      <Command>echo Deploying dwmapi.dll to $(GameDeployDir)...
+if not exist "$(GameDeployDir)" mkdir "$(GameDeployDir)"
+copy /Y "$(TargetPath)" "$(GameDeployDir)$(TargetFileName)"
+if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(TargetDir)$(TargetName).pdb" "$(GameDeployDir)$(TargetName).pdb"
+echo Deploy complete.</Command>
+      <Message>Copying dwmapi.dll to game server directory...</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="auto_update\auto_updater.h" />

--- a/Version_Mod_Loader/dllmain.cpp
+++ b/Version_Mod_Loader/dllmain.cpp
@@ -495,6 +495,16 @@ static DWORD WINAPI MainInitThreadProc(LPVOID)
 
 	ModLoaderLogger::LoadAllPlugins();
 
+	// Bug fix: if the GameInstanceInit one-shot latch fired before plugins
+	// were loaded (server startup race / 120s timeout scenario), plugins
+	// were left in "deferred" state and PluginInit was never called.
+	// Detect this and call InitAllLoadedPlugins now that the DLLs are loaded.
+	if (Hooks::GameInstanceInit::HasFired())
+	{
+		ModLoaderLogger::LogInfo(L"[dllmain] GameInstanceInit already fired before plugins loaded -- calling InitAllLoadedPlugins now");
+		ModLoaderLogger::InitAllLoadedPlugins();
+	}
+
 	Splash::SetStatus(L"Plugin DLLs loaded -- waiting for game instance...");
 	Splash::SetProgress(1.0f);
 

--- a/Version_Mod_Loader/hooks/game/game_instance_init/game_instance_init.cpp
+++ b/Version_Mod_Loader/hooks/game/game_instance_init/game_instance_init.cpp
@@ -66,6 +66,11 @@ namespace Hooks::GameInstanceInit
 		return ok;
 	}
 
+	bool HasFired()
+	{
+		return InterlockedCompareExchange(&g_initFired, 1, 1) == 1;
+	}
+
 	void Remove()
 	{
 		ModLoaderLogger::LogInfo(L"[GameInstanceInit] Removing hook...");

--- a/Version_Mod_Loader/hooks/game/game_instance_init/game_instance_init.h
+++ b/Version_Mod_Loader/hooks/game/game_instance_init/game_instance_init.h
@@ -24,6 +24,10 @@ namespace Hooks::GameInstanceInit
 	bool Install();
 	void Remove();
 
+	// Returns true if the one-shot init latch has already fired.
+	// Used by dllmain to detect the race where plugins loaded after the latch.
+	bool HasFired();
+
 	void RegisterProcessEventCallback(ProcessEventCallback cb);
 	void UnregisterProcessEventCallback(ProcessEventCallback cb);
 }


### PR DESCRIPTION
## Summary

* Initialize deferred plugins immediately if `GameInstanceInit` has already fired before plugin DLL loading completes
* Expose the `GameInstanceInit` fired state so startup can recover from the late-load server race

## Why

* A server startup race allowed plugins to be loaded after the one-shot `GameInstanceInit` latch had already fired
* In that case, plugins remained deferred and `PluginInit` was never called, so the plugin never fully started
