### PR TITLE
Plugins can now use the built in UE5 HTTP server to serve websites

### DIFF
--- a/HttpServer.md
+++ b/HttpServer.md
@@ -1,0 +1,293 @@
+# HttpServer Plugin API (v22, server only)
+
+The `IPluginHttpServer` interface lets plugins serve HTTP content directly through the game
+server's built-in HTTP listener. It is available from interface version 22 onwards and is
+server-only -- `hooks->HttpServer` is `nullptr` on client and generic builds.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [URL Scheme](#url-scheme)
+- [Request Processing Order](#request-processing-order)
+- [MIME Type Support](#mime-type-support)
+- [Static File Routes](#static-file-routes)
+- [Raw Response Routes (JSON APIs)](#raw-response-routes-json-apis)
+- [Raw Request Filters](#raw-request-filters)
+- [Thread Safety](#thread-safety)
+- [PluginHttpRequest Reference](#pluginhttprequest-reference)
+- [PluginHttpResponse Reference](#pluginhttpresponse-reference)
+- [Full Example Plugin](#full-example-plugin)
+- [Common Mistakes](#common-mistakes)
+
+---
+
+## Overview
+
+Every incoming HTTP request is routed through a three-stage pipeline:
+
+```
+Request
+|
+  v
+[1] Raw-request filters    --- first Deny -> 403, stop
+  |
+  v
+[2] Raw-response routes    --- first prefix match -> plugin callback, stop
+  |
+  v
+[3] Static-file routes     --- first prefix match -> file served from disk, stop
+  |
+  v
+[4] Engine pass-through    --- original engine handler (404 for unknown paths)
+```
+
+---
+
+## URL Scheme
+
+All plugin-owned URLs follow this pattern (always case-insensitive):
+
+```
+/<pluginName>/<routeName>/[optional/sub/path]
+```
+
+- `<pluginName>` -- the exact value of `self->name` as returned by `GetPluginInfo()`.
+- `<routeName>`  -- the `folderName` (static) or `urlPrefix` (raw route) passed at registration.
+
+Examples for a plugin named `MyPlugin`:
+
+| Route type   | Registration call              | Matched URLs       |
+|--------------|--------------------------------|---------------------------------------------------|
+| Static files | `AddRoute(self, "ui")` | `/myplugin/ui/index.html`, `/myplugin/ui/app.js`  |
+| Raw route    | `AddRawRoute(self, "api", cb)` | `/myplugin/api/`, `/myplugin/api/status`         |
+
+URL matching is case-insensitive. The plugin name and route name are lowercased for the
+prefix comparison, but the original casing is preserved in `req->url`.
+
+---
+
+## Request Processing Order
+
+1. **Raw-request filters** -- run first, for every request regardless of URL. A filter
+   returning `HttpRequestAction::Deny` immediately sends a `403 Forbidden` and stops all
+   further processing. Use filters for authentication, rate-limiting, or blanket blocking.
+
+2. **Raw-response routes** -- prefix-matched against the URL. The first match wins; the
+   matched plugin callback is called and its response is sent. No other handler runs.
+
+3. **Static-file routes** -- prefix-matched against the URL. The file path is resolved on
+   disk, validated to prevent path traversal, and served with an inferred MIME type. For
+   directory requests (no file extension in the last path segment) the server probes
+   `index.html` then `index.htm` before giving up.
+
+4. **Engine pass-through** -- the original game HTTP handler. Produces `404 Not Found` for
+   paths it does not recognise.
+
+---
+
+## MIME Type Support
+
+The following file extensions are recognised automatically for static file routes:
+
+| Extension        | MIME type          |
+|--------------------|---------------------------|
+| `.html`, `.htm`    | `text/html`|
+| `.css`        | `text/css`            |
+| `.js`         | `application/javascript`  |
+| `.json`  | `application/json`  |
+| `.txt`             | `text/plain`       |
+| `.xml`  | `text/xml`             |
+| `.svg`   | `image/svg+xml`           |
+| `.png`  | `image/png`               |
+| `.jpg`, `.jpeg`    | `image/jpeg`      |
+| `.gif`   | `image/gif`               |
+| `.ico`  | `image/x-icon`  |
+| `.wasm`    | `application/wasm`        |
+| (anything else)    | `application/octet-stream`|
+
+Text types (`text/*`, `application/javascript`, `application/json`, `image/svg+xml`) are
+sent through the engine's UTF-16 string path. All other types are sent as raw bytes --
+binary files such as PNG and JPEG are served without any encoding conversion and arrive
+at the browser intact.
+
+---
+
+## Static File Routes
+
+Serve a folder of files from disk.
+
+### Registration
+
+```cpp
+// In PluginInit:
+if (self->hooks->HttpServer)
+{
+    if (self->hooks->HttpServer->AddRoute(self, "ui"))
+        LOG_INFO("Static route registered: /%s/ui/", self->name);
+    else
+        LOG_WARN("Static route registration failed (already registered?)");
+}
+```
+
+Files are served from:
+
+```
+<exe_dir>\Plugins\<pluginName>\<folderName>\
+```
+
+For example, if your plugin is `MyPlugin` and your folder is `ui`, the server looks for
+files under:
+
+```
+StarRupture\Binaries\Win64\Plugins\MyPlugin\ui\
+```
+
+### Directory requests
+
+A request whose last URL segment has no file extension is treated as a directory request.
+The server probes:
+
+1. `index.html`
+2. `index.htm`
+
+If neither exists the engine's 404 handler responds.
+
+### Filename URLs with trailing slashes
+
+The game server normalises all URLs by appending a trailing slash before routing. The
+static file handler strips it before path resolution, so a request for `index.html/` is
+correctly treated as a request for `index.html`.
+
+### Unregistration
+
+Always call `RemoveRoute` during `PluginShutdown`:
+
+```cpp
+// In PluginShutdown:
+if (g_self && g_self->hooks->HttpServer)
+    g_self->hooks->HttpServer->RemoveRoute(g_self, "ui");
+```
+
+---
+
+## Raw Response Routes (JSON APIs)
+
+Serve dynamic content -- JSON, computed HTML, or anything else -- from a callback.
+
+### Registration
+
+```cpp
+static void OnApiRequest(const PluginHttpRequest* req, PluginHttpResponse* resp)
+{
+    static char s_buf[256];
+    int len = snprintf(s_buf, sizeof(s_buf), "{\"status\":\"ok\"}");
+
+    resp->statusCode  = 200;
+    resp->contentType = "application/json";
+    resp->body        = s_buf;
+    resp->bodyLen     = (len > 0) ? static_cast<size_t>(len) : 0;
+}
+
+// In PluginInit:
+if (self->hooks->HttpServer)
+{
+    if (self->hooks->HttpServer->AddRawRoute(self, "api", OnApiRequest))
+        LOG_INFO("Raw route registered: /%s/api/", self->name);
+}
+```
+
+The callback is invoked for any URL that starts with `/<pluginName>/<urlPrefix>/`
+(case-insensitive). The full original URL is available in `req->url` so you can dispatch
+sub-paths manually.
+
+### Response fields
+
+| Field         | Type         | Description     |
+|---------------|----------------|----------------------------------------------------------|
+| `statusCode`  | `int`       | HTTP status code. Default `200`.   |
+| `contentType` | `const char*`  | MIME type string. Default `"text/plain"`.     |
+| `body`        | `const char*`  | Response body bytes. May be `nullptr` if `bodyLen == 0`. |
+| `bodyLen`     | `size_t`   | Byte length of `body`. `0` produces an empty body.       |
+
+All pointers in `PluginHttpResponse` must remain valid until the callback returns. The
+modloader copies them immediately after. Using a `static` buffer (as shown above) is the
+simplest approach.
+
+### Unregistration
+
+```cpp
+// In PluginShutdown:
+if (g_self && g_self->hooks->HttpServer)
+    g_self->hooks->HttpServer->RemoveRawRoute(g_self, "api");
+```
+
+---
+
+## Raw Request Filters
+
+Inspect or block every incoming request before any route handler runs.
+
+```cpp
+static HttpRequestAction OnFilter(const PluginHttpRequest* req)
+{
+    // Only block non-GET requests
+    if (req->method != HttpMethod::Get)
+   return HttpRequestAction::Deny;   // sends 403
+
+    return HttpRequestAction::Approve;    // continue normally
+}
+
+// In PluginInit:
+if (self->hooks->HttpServer)
+    self->hooks->HttpServer->RegisterOnRawRequest(OnFilter);
+
+// In PluginShutdown:
+if (g_self && g_self->hooks->HttpServer)
+    g_self->hooks->HttpServer->UnregisterOnRawRequest(OnFilter);
+```
+
+Filters are global -- they fire for all requests, not just your plugin's routes. Use them
+sparingly and return quickly.
+
+---
+
+## Thread Safety
+
+- HTTP callbacks are called from Unreal's **HTTP connection thread** -- the thread that
+  FHttpConnection::ProcessRequest runs on. This is entirely separate from the game thread
+  that UGameEngine::Tick (and all plugin tick callbacks) run on.
+- Do not access UObjects, game state, or any data written by the game thread without
+  proper synchronisation.
+- The recommended pattern is to write shared state on the game thread under a mutex, and
+  read it inside the HTTP callback under the same mutex. This is exactly what
+  NetChannelTest does for s_worldName:
+
+```cpp
+// Written on the game thread (world-begin-play callback):
+static void OnWorldBeginPlay(SDK::UWorld*, const char* worldName)
+{
+    std::lock_guard lock(s_mutex);   // game thread writer
+    strncpy_s(s_worldName, worldName ? worldName : "<unknown>", _TRUNCATE);
+}
+
+// Read on the HTTP connection thread (route callback):
+static void OnApiRoute(const PluginHttpRequest* req, PluginHttpResponse* resp)
+{
+    char worldName[256];
+    {
+        std::lock_guard lock(s_mutex);   // HTTP thread reader
+        strncpy_s(worldName, s_worldName, _TRUNCATE);
+    }
+    // ... build response from worldName ...
+}
+```
+
+- Plain reads of naturally-aligned 32-bit values (uint32_t, int, float) are atomic on
+  x86-64 and do not require a mutex when only one thread writes them and the read does
+  not need to be consistent with other values. NetChannelTest uses this for the tick/send
+  counters in OnApiRoute, but protects the world name string with a mutex because a
+  char[256] copy is not atomic.
+- Do not call PostToGameThread from inside an HTTP callback and then block waiting for the
+  result -- that will deadlock because the game thread is not blocked waiting for you.

--- a/NetChannelTest/plugin.cpp
+++ b/NetChannelTest/plugin.cpp
@@ -3,6 +3,10 @@
 #include "plugin_config.h"
 #include "plugin_network_helpers.h"
 
+#include <mutex>
+#include <cstdio>
+#include <cstring>
+
 static IPluginSelf* g_self = nullptr;
 
 IPluginSelf* GetSelf() { return g_self; }
@@ -26,6 +30,60 @@ struct AckPacket
 static uint32_t s_tickCount = 0;
 static uint32_t s_sendCount = 0;
 static float    s_uptime = 0.0f;
+
+// ---------------------------------------------------------------------------
+// World name — written from the world-begin-play callback, read from the
+// HTTP route callback (different threads). Protected by a mutex.
+// ---------------------------------------------------------------------------
+static std::mutex  s_worldNameMutex;
+static char        s_worldName[256] = "<unknown>";
+
+static void OnAnyWorldBeginPlay(SDK::UWorld* /*world*/, const char* worldName)
+{
+	std::lock_guard lock(s_worldNameMutex);
+	if (worldName && worldName[0])
+		strncpy_s(s_worldName, worldName, _TRUNCATE);
+	else
+		strncpy_s(s_worldName, "<unknown>", _TRUNCATE);
+}
+
+// Typed alias so the function pointer matches PluginAnyWorldBeginPlayCallback exactly.
+static const PluginAnyWorldBeginPlayCallback k_OnAnyWorldBeginPlay = &OnAnyWorldBeginPlay;
+
+static void OnApiRoute(const PluginHttpRequest* req, PluginHttpResponse* resp)
+{
+	// Copy stats atomically enough for a debug endpoint (plain reads of
+	// 32-bit values are atomic on x86-64; uptime is a float so read once).
+	const uint32_t ticks     = s_tickCount;
+	const uint32_t sends     = s_sendCount;
+	const float  uptime    = s_uptime;
+
+	char worldName[256];
+	{
+		std::lock_guard lock(s_worldNameMutex);
+		strncpy_s(worldName, s_worldName, _TRUNCATE);
+	}
+
+	static char s_jsonBuf[512];
+	const int written = snprintf(s_jsonBuf, sizeof(s_jsonBuf),
+		"{\n"
+		"  \"plugin\": \"NetChannelTest\",\n"
+		"  \"worldName\": \"%s\",\n"
+		"  \"tickCount\": %u,\n"
+		"  \"sendCount\": %u,\n"
+		"  \"uptime\": %.2f\n"
+		"}",
+		worldName, ticks, sends, uptime);
+
+	resp->statusCode  = 200;
+	resp->contentType = "application/json";
+	resp->body     = s_jsonBuf;
+	resp->bodyLen     = (written > 0) ? static_cast<size_t>(written) : 0;
+
+	if (g_self)
+		LOG_DEBUG("HTTP /api/ served: world=%s ticks=%u sends=%u uptime=%.1f",
+			worldName, ticks, sends, uptime);
+}
 
 // Server->Client receive handle (client side)
 static PluginNetworkMessageCallback s_receiveHandle = nullptr;
@@ -84,6 +142,7 @@ extern "C" {
 					LOG_INFO("Received AckPacket from client: ackedSendCount=%u", ack.ackedSendCount);
 				});
 
+			/*
 			self->hooks->Engine->RegisterOnTick([](float deltaTime) {
 				if (!g_self || !g_self->hooks->Network) return;
 
@@ -105,6 +164,32 @@ extern "C" {
 
 				LOG_DEBUG("Sent TestPacket #%u (tick=%u uptime=%.1fs)", s_sendCount, s_tickCount, s_uptime);
 			});
+			*/
+
+			// ---------------------------------------------------------------
+			// HTTP routes (v22, server only)
+			// ---------------------------------------------------------------
+			if (self->hooks->HttpServer)
+			{
+				// Track world name for the API route
+				self->hooks->World->RegisterOnAnyWorldBeginPlay(k_OnAnyWorldBeginPlay);
+
+				// Raw JSON API: GET /netchanneltest/api/
+				if (self->hooks->HttpServer->AddRawRoute(self, "api", OnApiRoute))
+					LOG_INFO("HTTP raw route registered: /netchanneltest/api/");
+				else
+					LOG_WARN("HTTP raw route registration failed (already registered?)");
+
+				/* Static file route: /netchanneltest/ui/  ->  Plugins\NetChannelTest\ui\ */
+				if (self->hooks->HttpServer->AddRoute(self, "ui"))
+					LOG_INFO("HTTP static route registered: /netchanneltest/ui/");
+				else
+					LOG_WARN("HTTP static route registration failed (already registered?)");
+			}
+			else
+			{
+				LOG_INFO("HttpServer not available (client build or loader < v22) -- HTTP routes skipped");
+			}
 		}
 		else
 		{
@@ -148,6 +233,17 @@ extern "C" {
 						g_self, typeid(AckPacket).name(), s_serverReceiveHandle);
 					s_serverReceiveHandle = nullptr;
 				}
+
+				// Unregister HTTP routes and world name callback
+				if (g_self->hooks->HttpServer)
+				{
+					g_self->hooks->HttpServer->RemoveRawRoute(g_self, "api");
+					g_self->hooks->HttpServer->RemoveRoute(g_self, "ui");
+					LOG_INFO("HTTP routes unregistered");
+				}
+
+				if (g_self->hooks->World)
+					g_self->hooks->World->UnregisterOnAnyWorldBeginPlay(k_OnAnyWorldBeginPlay);
 			}
 			else
 			{
@@ -163,6 +259,11 @@ extern "C" {
 		s_tickCount = 0;
 		s_sendCount = 0;
 		s_uptime    = 0.0f;
+
+		{
+			std::lock_guard lock(s_worldNameMutex);
+			strncpy_s(s_worldName, "<unknown>", _TRUNCATE);
+		}
 
 		g_self = nullptr;
 	}

--- a/ServerUtility/hooks/http_connection/http_connection.cpp
+++ b/ServerUtility/hooks/http_connection/http_connection.cpp
@@ -2,127 +2,31 @@
 #include "plugin_helpers.h"
 #include "plugin_config.h"
 
-#include <Windows.h>
-#include <cstdint>
 #include <cstring>
 #include <string>
-#include <vector>
-#include <cwchar>
 
 // ---------------------------------------------------------------------------
-// FHttpConnection::ProcessRequest hook
+// FHttpConnection::ProcessRequest — Remote-Object-Call vulnerability filter
 //
-// Signature (from IDA):
-// void __fastcall FHttpConnection::ProcessRequest(__int64 a1, _QWORD *a2, __int64 a3)
+// This hook is now owned by the modloader (Hooks::HttpServer).
+// ServerUtility registers a raw-request filter through IPluginHttpServer so
+// it can deny unauthorised /remote/object/call requests.  No pattern scanning,
+// no memory helpers, and no response construction live here any more — those
+// responsibilities belong entirely to the modloader subsystem.
 //
-// a2 is a TSharedPtr<FHttpServerRequest> — *a2 is the raw request pointer.
-// a3 is a TFunction<void(TUniquePtr<FHttpServerResponse>&&)> — the response callback.
-//
-// Confirmed FHttpServerRequest offsets (verified experimentally):
-//   obj+16  : FString RelativePath  { wchar_t* Data @+16, int32 Num @+24 }
-//   obj+280 : TArray<uint8> Body    { uint8*   Data @+280, int32 Num @+288 }
-//
-// Pattern:
-// 48 89 5C 24 ?? 55 56 41 54 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 83 79
+// The only logic retained is:
+//   1. Check the configured enable flag.
+//   2. Inspect the URL and, when it matches /remote/object/call, inspect the
+//      JSON body for an objectPath that is not in the allow-list.
+//   3. Return HttpRequestAction::Deny to make the modloader send a 403.
 // ---------------------------------------------------------------------------
 
-static constexpr auto PROCESS_REQUEST_PATTERN =
-	"48 89 5C 24 ?? 55 56 41 54 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 83 79";
-
-static constexpr size_t URL_OFFSET = 16;
-static constexpr size_t BODY_OFFSET = 280;
-
-static constexpr auto REMOTE_CALL_URL = "/remote/object/call";
+static constexpr auto REMOTE_CALL_URL  = "/remote/object/call";
 static constexpr auto ALLOWED_OBJECT_PATH =
 	"/Game/Chimera/Maps/DedicatedServerStart.DedicatedServerStart:PersistentLevel.BP_DedicatedServerSettingsActor_C_1.DedicatedServerSettingsComp";
 
 // ---------------------------------------------------------------------------
-// Hook state
-// ---------------------------------------------------------------------------
-using ProcessRequest_t = void(__fastcall*)(__int64 a1, uint64_t* a2, __int64 a3);
-static ProcessRequest_t g_originalProcessRequest = nullptr;
-static HookHandle g_hookHandle = nullptr;
-
-// Address of FHttpServerResponse::Error — resolved at install time by scanning
-// the bytes of ProcessRequest for "mov edx, 404 (0x194)" followed by a CALL.
-// typedef: void __fastcall FHttpServerResponse_Error(void** outPtr, int32 code, FString* errCode, FString* errMsg)
-using FHttpServerResponseError_t = void(__fastcall*)(void** outPtr, int32_t code, void* errCode, void* errMsg);
-static uintptr_t g_errorFuncAddr = 0;
-
-// ---------------------------------------------------------------------------
-// Safe memory helpers
-// ---------------------------------------------------------------------------
-static bool IsReadableMemory(uintptr_t addr, size_t size)
-{
-	if (!addr || !size) return false;
-	MEMORY_BASIC_INFORMATION mbi;
-	if (!VirtualQuery(reinterpret_cast<LPCVOID>(addr), &mbi, sizeof(mbi))) return false;
-	if (mbi.State != MEM_COMMIT) return false;
-	if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
-	return addr + size <= reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
-}
-
-static size_t TryReadBytes(uintptr_t addr, void* out, size_t len)
-{
-	if (!IsReadableMemory(addr, 1)) return 0;
-	MEMORY_BASIC_INFORMATION mbi;
-	if (!VirtualQuery(reinterpret_cast<LPCVOID>(addr), &mbi, sizeof(mbi))) return 0;
-	uintptr_t regionEnd = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
-	size_t readable = (regionEnd > addr) ? (regionEnd - addr) : 0;
-	size_t n = len < readable ? len : readable;
-	__try { memcpy(out, reinterpret_cast<const void*>(addr), n); }
-	__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
-	return n;
-}
-
-// ---------------------------------------------------------------------------
-// Request field readers
-// ---------------------------------------------------------------------------
-
-// Reads FString at req+offset and returns it as a UTF-8 std::string.
-static std::string ReadFStringUtf8(uintptr_t req, size_t offset)
-{
-	uintptr_t dataPtr = 0;
-	if (TryReadBytes(req + offset, &dataPtr, sizeof(dataPtr)) != sizeof(dataPtr) || !dataPtr)
-		return {};
-
-	std::vector<wchar_t> wbuf(512);
-	size_t got = TryReadBytes(dataPtr, wbuf.data(), wbuf.size() * sizeof(wchar_t));
-	size_t numChars = got / sizeof(wchar_t);
-
-	size_t len = 0;
-	while (len < numChars && wbuf[len]) ++len;
-	if (!len) return {};
-
-	int needed = WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), nullptr, 0, nullptr, nullptr);
-	if (needed <= 0) return {};
-	std::string out(needed, '\0');
-	WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), &out[0], needed, nullptr, nullptr);
-	return out;
-}
-
-// Reads TArray<uint8> at req+offset and returns the bytes as a std::string.
-static std::string ReadByteArray(uintptr_t req, size_t offset)
-{
-	uintptr_t dataPtr = 0;
-	if (TryReadBytes(req + offset, &dataPtr, sizeof(dataPtr)) != sizeof(dataPtr) || !dataPtr)
-		return {};
-
-	int32_t num = 0;
-	if (TryReadBytes(req + offset + 8, &num, sizeof(num)) != sizeof(num) || num <= 0 || num > 16 * 1024 * 1024)
-		return {};
-
-	if (!IsReadableMemory(dataPtr, static_cast<size_t>(num)))
-		return {};
-
-	std::string out(static_cast<size_t>(num), '\0');
-	if (TryReadBytes(dataPtr, &out[0], static_cast<size_t>(num)) != static_cast<size_t>(num))
-		return {};
-	return out;
-}
-
-// ---------------------------------------------------------------------------
-// Minimal JSON string-value extractor
+// Minimal JSON string-value extractor — unchanged from original
 // Handles: "key": "value"  with basic escape sequences.
 // ---------------------------------------------------------------------------
 static std::string ExtractJsonString(const std::string& json, const char* key)
@@ -132,8 +36,9 @@ static std::string ExtractJsonString(const std::string& json, const char* key)
 	if (pos == std::string::npos) return {};
 	pos += needle.size();
 
-	while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == ':' || json[pos] == '\n' || json[
-		pos] == '\r'))
+	while (pos < json.size() &&
+	       (json[pos] == ' ' || json[pos] == '\t' ||
+	        json[pos] == ':' || json[pos] == '\n' || json[pos] == '\r'))
 		++pos;
 
 	if (pos >= json.size() || json[pos] != '"') return {};
@@ -148,20 +53,13 @@ static std::string ExtractJsonString(const std::string& json, const char* key)
 			++pos;
 			switch (json[pos])
 			{
-			case '"': value += '"';
-				break;
-			case '\\': value += '\\';
-				break;
-			case '/': value += '/';
-				break;
-			case 'n': value += '\n';
-				break;
-			case 'r': value += '\r';
-				break;
-			case 't': value += '\t';
-				break;
-			default: value += json[pos];
-				break;
+			case '"':  value += '"';  break;
+			case '\\': value += '\\'; break;
+			case '/':  value += '/';  break;
+			case 'n':  value += '\n'; break;
+			case 'r':  value += '\r'; break;
+			case 't':  value += '\t'; break;
+			default:   value += json[pos]; break;
 			}
 		}
 		else
@@ -172,190 +70,28 @@ static std::string ExtractJsonString(const std::string& json, const char* key)
 }
 
 // ---------------------------------------------------------------------------
-// FHttpServerResponse::Error discovery
-//
-// Scans the bytes of FHttpConnection::ProcessRequest for the instruction
-// sequence "mov edx, 0x194" (BA 94 01 00 00 = 404 decimal) immediately
-// followed by a direct CALL (E8).  The only call with that exact second
-// argument inside ProcessRequest is FHttpServerResponse::Error.
+// Raw-request filter callback
+// Registered with hooks->HttpServer->RegisterOnRawRequest during Install().
 // ---------------------------------------------------------------------------
-static uintptr_t FindErrorFunction(uintptr_t processRequestAddr)
+static HttpRequestAction RemoteCallFilter(const PluginHttpRequest* req)
 {
-	uint8_t buf[4096] = {};
-	size_t got = TryReadBytes(processRequestAddr, buf, sizeof(buf));
-	if (got < 16) return 0;
+	if (!ServerUtilityConfig::Config::GetRemoteVulnerabilityPatch())
+		return HttpRequestAction::Approve;
 
-	// BA 94 01 00 00 = mov edx, 194h (404)
-	static const uint8_t kMov404[] = {0xBA, 0x94, 0x01, 0x00, 0x00};
+	if (strcmp(req->url, REMOTE_CALL_URL) != 0)
+		return HttpRequestAction::Approve;
 
-	for (size_t i = 0; i + 40 < got; ++i)
-	{
-		if (memcmp(buf + i, kMov404, sizeof(kMov404)) != 0)
-			continue;
+	std::string body(req->body ? req->body : "", req->bodyLen);
+	std::string objectPath  = ExtractJsonString(body, "objectPath");
+	std::string functionName = ExtractJsonString(body, "functionName");
 
-		// Scan forward up to 40 bytes for a direct relative CALL (E8 xx xx xx xx)
-		for (size_t j = i + sizeof(kMov404); j + 5 <= got && j < i + 40; ++j)
-		{
-			if (buf[j] != 0xE8)
-				continue;
+	if (objectPath.find(ALLOWED_OBJECT_PATH) != std::string::npos)
+		return HttpRequestAction::Approve;
 
-			int32_t rel = 0;
-			memcpy(&rel, buf + j + 1, sizeof(rel));
-			uintptr_t target = processRequestAddr + j + 5 + static_cast<intptr_t>(rel);
-
-			if (IsReadableMemory(target, 16))
-				return target;
-		}
-	}
-	return 0;
-}
-
-// ---------------------------------------------------------------------------
-// 403 response sender
-//
-// Constructs a real FHttpServerResponse via FHttpServerResponse::Error and
-// fires it through the a3 TFunction callback.
-//
-// TFunction invocation sequence is taken verbatim from the ProcessRequest
-// pseudocode (confirmed offsets — see comment block at top of file):
-//
-//   v15 = a3 + 16                                  // default: inline storage
-//   v16 = *(func_ptr*)a3                            // the invoke wrapper fn
-//   if (*QWORD(a3 + 40)) v15 = *QWORD(a3 + 40)    // override with heap storage
-//   v17 = (*(vtable[1] of v15))(v15)               // get bound callable target
-//   v16(v17, &response)                             // invoke
-//
-// FString layout on x64 (TArray<wchar_t, TSizedHeapAllocator<32>>):
-//   { wchar_t* Data(8), int32 Num(4), int32 Max(4) }  = 16 bytes
-// ---------------------------------------------------------------------------
-
-// Must match TArray<wchar_t> layout exactly.
-struct FakeString
-{
-	wchar_t* Data;
-	int32_t Num;
-	int32_t Max;
-};
-
-using CallbackInvokeFn = void(__fastcall*)(__int64 callable, void** response);
-using CallbackGetTargetFn = __int64(__fastcall*)(__int64 storage);
-
-static void SendBlockedResponse(__int64 a1, __int64 a3)
-{
-	if (!g_errorFuncAddr)
-	{
-		LOG_WARN(
-			"[RemoteVulnerabilityPatcher] FHttpServerResponse::Error not located — connection dropped without response");
-		return;
-	}
-
-	auto* hooks = GetHooks();
-	if (!hooks || !hooks->Memory || !hooks->Memory->IsAllocatorAvailable())
-	{
-		LOG_WARN("[RemoteVulnerabilityPatcher] Engine allocator unavailable — connection dropped without response");
-		return;
-	}
-
-	// Build engine-heap-allocated FString for the error code.
-	// Using the same naming convention as UE5's built-in error codes.
-	static constexpr wchar_t kErrorCode[] = L"errors.com.epicgames.httpserver.forbidden";
-	static constexpr int32_t kErrorCodeChars = sizeof(kErrorCode) / sizeof(wchar_t); // includes null
-
-	auto errData = static_cast<wchar_t*>(
-		hooks->Memory->Alloc(sizeof(kErrorCode), 4));
-	if (!errData)
-	{
-		LOG_WARN("[RemoteVulnerabilityPatcher] EngineAlloc failed — connection dropped without response");
-		return;
-	}
-	memcpy(errData, kErrorCode, sizeof(kErrorCode));
-
-	FakeString errCodeStr = {errData, kErrorCodeChars - 1, kErrorCodeChars}; // Num excludes null
-	FakeString emptyStr = {nullptr, 0, 0};
-
-	// Create the 403 response.  Error() will move-from the FStrings (Data → null on move).
-	void* response = nullptr;
-	reinterpret_cast<FHttpServerResponseError_t>(g_errorFuncAddr)(
-		&response, 403, &errCodeStr, &emptyStr);
-
-	// Free error code data if not taken (i.e. Error() copied rather than moved).
-	if (errCodeStr.Data)
-		hooks->Memory->Free(errCodeStr.Data);
-
-	if (!response)
-	{
-		LOG_WARN(
-			"[RemoteVulnerabilityPatcher] FHttpServerResponse::Error returned null — connection dropped without response");
-		return;
-	}
-
-	// The response callback asserts state == AwaitingProcessing (2).
-	// The original ProcessRequest calls FHttpConnection::ChangeState(a1, 2) as its
-	// first action — which we bypassed.  State is stored at a1+24 (confirmed from
-	// the pseudocode assertion: *(_DWORD*)(a1+24) != 1).
-	__try { *reinterpret_cast<int32_t*>(a1 + 24) = 2; }
-	__except (EXCEPTION_EXECUTE_HANDLER)
-	{
-		LOG_ERROR("[RemoteVulnerabilityPatcher] Failed to set connection state — connection dropped without response");
-		return;
-	}
-
-	// Invoke the TFunction<void(TUniquePtr<FHttpServerResponse>&&)> callback.
-	// Replicates the invocation sequence from the ProcessRequest pseudocode exactly.
-	__try
-	{
-		CallbackInvokeFn invoke = *reinterpret_cast<CallbackInvokeFn*>(a3);
-		__int64 storage = a3 + 16;
-
-		if (*reinterpret_cast<__int64*>(a3 + 40))
-			storage = *reinterpret_cast<__int64*>(a3 + 40);
-
-		__int64* vtable = *reinterpret_cast<__int64**>(storage);
-		auto getTarget = reinterpret_cast<CallbackGetTargetFn>(vtable[1]);
-		__int64 target = getTarget(storage);
-
-		invoke(target, &response);
-	}
-	__except (EXCEPTION_EXECUTE_HANDLER)
-	{
-		LOG_ERROR("[RemoteVulnerabilityPatcher] Exception during response callback invocation");
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Detour
-// ---------------------------------------------------------------------------
-static void __fastcall Hook_ProcessRequest(__int64 a1, uint64_t* a2, __int64 a3)
-{
-	if (a2)
-	{
-		uint64_t p = 0;
-		if (TryReadBytes(reinterpret_cast<uintptr_t>(a2), &p, sizeof(p)) == sizeof(p) && p != 0)
-		{
-			std::string url = ReadFStringUtf8(p, URL_OFFSET);
-			std::string body = ReadByteArray(p, BODY_OFFSET);
-
-			// Security: block unauthorized /remote/object/call requests
-			if (ServerUtilityConfig::Config::GetRemoteVulnerabilityPatch()
-				&& url == REMOTE_CALL_URL)
-			{
-				std::string objectPath = ExtractJsonString(body, "objectPath");
-				std::string functionName = ExtractJsonString(body, "functionName");
-
-				if (objectPath.find(ALLOWED_OBJECT_PATH) == std::string::npos)
-				{
-					LOG_WARN("[RemoteVulnerabilityPatcher] Blocked unauthorized /remote/object/call");
-					LOG_WARN("[RemoteVulnerabilityPatcher]   objectPath:   '%s'", objectPath.c_str());
-					LOG_WARN("[RemoteVulnerabilityPatcher]   functionName: '%s'", functionName.c_str());
-					SendBlockedResponse(a1, a3);
-					return;
-				}
-			}
-		}
-	}
-
-	if (g_originalProcessRequest)
-		g_originalProcessRequest(a1, a2, a3);
+	LOG_WARN("[RemoteVulnerabilityPatcher] Blocked unauthorized /remote/object/call");
+	LOG_WARN("[RemoteVulnerabilityPatcher]   objectPath:   '%s'", objectPath.c_str());
+	LOG_WARN("[RemoteVulnerabilityPatcher]   functionName: '%s'", functionName.c_str());
+	return HttpRequestAction::Deny;
 }
 
 // ---------------------------------------------------------------------------
@@ -363,71 +99,26 @@ static void __fastcall Hook_ProcessRequest(__int64 a1, uint64_t* a2, __int64 a3)
 // ---------------------------------------------------------------------------
 void HttpConnectionHook::Install()
 {
-	auto* scanner = GetScanner();
 	auto* hooks = GetHooks();
-	if (!scanner || !hooks)
+	if (!hooks || !hooks->HttpServer)
 	{
-		LOG_ERROR("[RemoteVulnerabilityPatcher] Scanner or hooks interface not available");
+		LOG_ERROR("[RemoteVulnerabilityPatcher] HttpServer interface not available — filter not registered");
 		return;
 	}
 
-	LOG_INFO("[RemoteVulnerabilityPatcher] Scanning for FHttpConnection::ProcessRequest...");
-
-	uintptr_t addr = scanner->FindPatternInMainModule(PROCESS_REQUEST_PATTERN);
-	if (addr == 0)
-	{
-		LOG_ERROR(
-			"[RemoteVulnerabilityPatcher] Pattern scan failed - could not locate FHttpConnection::ProcessRequest");
-		return;
-	}
-
-	LOG_INFO("[RemoteVulnerabilityPatcher] Found FHttpConnection::ProcessRequest at 0x%llX",
-	         static_cast<unsigned long long>(addr));
-
-	// Scan ProcessRequest's own bytes to find FHttpServerResponse::Error.
-	// The function calls Error(out, 404, errCode, errMsg) for the not-found path —
-	// we look for "mov edx, 0x194" (BA 94 01 00 00) then the following E8 CALL.
-	g_errorFuncAddr = FindErrorFunction(addr);
-	if (g_errorFuncAddr)
-		LOG_DEBUG("[RemoteVulnerabilityPatcher] Found FHttpServerResponse::Error at 0x%llX",
-	          static_cast<unsigned long long>(g_errorFuncAddr));
-		else
-			LOG_WARN(
-			"[RemoteVulnerabilityPatcher] Could not locate FHttpServerResponse::Error — blocked requests will drop the connection instead of receiving a 403");
-
-	g_hookHandle = hooks->Hooks->Install(
-		addr,
-		reinterpret_cast<void*>(&Hook_ProcessRequest),
-		reinterpret_cast<void**>(&g_originalProcessRequest));
-
-	if (!g_hookHandle)
-	{
-		LOG_ERROR("[RemoteVulnerabilityPatcher] InstallHook failed!");
-		return;
-	}
-
-	LOG_INFO("[RemoteVulnerabilityPatcher] Hook installed successfully (handle=%p)", g_hookHandle);
+	hooks->HttpServer->RegisterOnRawRequest(&RemoteCallFilter);
+	LOG_INFO("[RemoteVulnerabilityPatcher] Raw-request filter registered");
 }
 
 void HttpConnectionHook::Remove()
 {
-	if (!g_hookHandle)
+	auto* hooks = GetHooks();
+	if (!hooks || !hooks->HttpServer)
 	{
-		LOG_DEBUG("[RemoteVulnerabilityPatcher] No hook installed - nothing to remove");
+		LOG_DEBUG("[RemoteVulnerabilityPatcher] HttpServer interface not available — nothing to remove");
 		return;
 	}
 
-	LOG_INFO("[RemoteVulnerabilityPatcher] Removing hook (handle=%p)...", g_hookHandle);
-
-	auto* hooks = GetHooks();
-	if (hooks && hooks->Hooks)
-		hooks->Hooks->Remove(g_hookHandle);
-	else
-		LOG_WARN("[RemoteVulnerabilityPatcher] Hook interface not available - cannot remove hook cleanly");
-
-	g_hookHandle = nullptr;
-	g_originalProcessRequest = nullptr;
-	g_errorFuncAddr = 0;
-
-	LOG_INFO("[RemoteVulnerabilityPatcher] Hook removed successfully");
+	hooks->HttpServer->UnregisterOnRawRequest(&RemoteCallFilter);
+	LOG_INFO("[RemoteVulnerabilityPatcher] Raw-request filter unregistered");
 }

--- a/ServerUtility/rcon/rcon.cpp
+++ b/ServerUtility/rcon/rcon.cpp
@@ -260,6 +260,10 @@ void Rcon::Init()
 	const uint16_t port = ReadRconPort();
 	const std::string password = ReadRconPassword();
 
+	// always register the stop command so we can shut down even if no password/port is configured
+	auto& cmds = CommandHandler::Get();
+	Cmd_Stop::Register(cmds);
+
 	if (port == 0 || password.empty())
 	{
 		if (port == 0 || password.empty())
@@ -284,9 +288,8 @@ void Rcon::Init()
 	LOG_INFO("[Rcon] Server name: %s", servName.c_str());
 
 	// Register built-in commands
-	auto& cmds = CommandHandler::Get();
+	
 	Cmd_Players::Register(cmds);
-	Cmd_Stop::Register(cmds);
 	Cmd_Save::Register(cmds);
 
 	// Start UDP query server (always)

--- a/StarRupture-ModLoader.sln
+++ b/StarRupture-ModLoader.sln
@@ -109,7 +109,8 @@ Global
 		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Local SDK Server Release|x64.Build.0 = Local SDK Server Release|x64
 		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Release|x64.ActiveCfg = Release|x64
 		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Release|x64.Build.0 = Release|x64
-		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Server Debug|x64.ActiveCfg = Server Release|x64
+		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Server Debug|x64.ActiveCfg = Server Debug|x64
+		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Server Debug|x64.Build.0 = Server Debug|x64
 		{F1A2B3C4-D5E6-4789-90AB-CDEF12345678}.Server Release|x64.ActiveCfg = Server Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution

--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj
@@ -501,6 +501,7 @@
     <ClInclude Include="hooks\game\world_end_play\world_end_play.h" />
     <ClInclude Include="hooks\hooks_common.h" />
     <ClInclude Include="hooks\hooks_interface.h" />
+    <ClInclude Include="hooks\http\http_server_hook.h" />
     <ClInclude Include="hooks\input\keybind_registry.h" />
     <ClInclude Include="hooks\input\input_processor.h" />
     <ClInclude Include="imgui\imgui.h" />
@@ -555,6 +556,7 @@
     <ClCompile Include="hooks\game\engine_tick\engine_tick.cpp" />
     <ClCompile Include="hooks\game\client_message\client_message.cpp" />
     <ClCompile Include="hooks\game\server_chat_commit\server_chat_commit.cpp" />
+    <ClCompile Include="hooks\http\http_server_hook.cpp" />
     <ClCompile Include="utils\game_thread_dispatch.cpp" />
     <ClCompile Include="hooks\game\hud_post_render\hud_post_render.cpp" />
     <ClCompile Include="hooks\game\experience_load_complete\experience_load_complete.cpp" />

--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj.filters
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj.filters
@@ -97,6 +97,12 @@
     <Filter Include="Source Files\UI\modloader">
       <UniqueIdentifier>{f2a4b6c8-9d0e-4f1a-b2c3-5d7e8f9a0b1c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\hooks\game\game_instance">
+      <UniqueIdentifier>{10a31f74-27ab-48fd-b200-79a0f0a9e443}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\hooks\game\FHttpServerRequest">
+      <UniqueIdentifier>{06d5eb1a-4870-4cab-b7a0-4f47674a29b9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dwmapi_proxy.h">
@@ -238,6 +244,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="logging\logger_interface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="hooks\http\http_server_hook.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -387,7 +396,10 @@
       <Filter>Source Files\UI</Filter>
     </ClCompile>
     <ClCompile Include="hooks\game\game_instance_init\game_instance_init.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\hooks\game\game_instance</Filter>
+    </ClCompile>
+    <ClCompile Include="hooks\http\http_server_hook.cpp">
+      <Filter>Source Files\hooks\game\FHttpServerRequest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Version_Mod_Loader/dllmain.cpp
+++ b/Version_Mod_Loader/dllmain.cpp
@@ -27,6 +27,10 @@
 #include "network_channel/network_channel.h"
 #include "hooks/game/game_instance_init/game_instance_init.h"
 
+#ifdef MODLOADER_SERVER_BUILD
+#include "hooks/http/http_server_hook.h"
+#endif
+
 #include "auto_update/auto_updater.h"
 
 #include "utils/thread_utils.h"
@@ -360,6 +364,14 @@ static DWORD WINAPI MainInitThreadProc(LPVOID)
 	Hooks::MassSpawnerDeactivate::Install();
 	Hooks::MassDoSpawning::Install();
 
+#ifdef MODLOADER_SERVER_BUILD
+	Splash::SetStatus(L"Installing HTTP server hook...");
+	if (Hooks::HttpServer::Install())
+		ModLoaderLogger::LogDebug(L"  HttpServer hook installed");
+	else
+		ModLoaderLogger::LogWarn(L"  WARNING: HttpServer hook failed — static file routes and request filters will not function");
+#endif
+
 	Splash::SetStatus(L"Installing GameInstance hook...");
 	Splash::SetProgress(0.65f);
 	// Install UGameInstance::Init hook.  Pattern scanning works at any time
@@ -503,7 +515,7 @@ static DWORD WINAPI MainInitThreadProc(LPVOID)
 	if (Hooks::GameInstanceInit::HasFired())
 	{
 		ModLoaderLogger::LogInfo(L"[dllmain] GameInstanceInit already fired before plugins loaded -- calling InitAllLoadedPlugins now");
-		ModLoaderLogger::InitAllLoadedPlugins();
+		PluginManager::InitAllLoadedPlugins();
 	}
 
 	Splash::SetStatus(L"Plugin DLLs loaded -- waiting for game instance...");
@@ -786,7 +798,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 		ModLoaderLogger::LogInfo(L"Engine shutdown hook removed");
 
 		// Now safe to unload plugins
-		ModLoaderLogger::UnloadAllPlugins();
+		PluginManager::UnloadAllPlugins();
 		NetworkChannel::Shutdown();
 
 		// Remove remaining core game hooks
@@ -801,6 +813,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 		Hooks::MassSpawnerActivate::Remove();
 		Hooks::MassSpawnerDeactivate::Remove();
 		Hooks::MassDoSpawning::Remove();
+#ifdef MODLOADER_SERVER_BUILD
+		Hooks::HttpServer::Remove();
+#endif
 #ifdef MODLOADER_CLIENT_BUILD
 		if (s_imguiEnabled)
 			UI::ImGuiBackend::Shutdown();

--- a/Version_Mod_Loader/hooks/game/scan_patterns.h
+++ b/Version_Mod_Loader/hooks/game/scan_patterns.h
@@ -79,6 +79,16 @@ namespace ScanPatterns
 	inline constexpr auto UMassSignalSubsystem_SignalEntity =
 		"48 89 5C 24 ?? 4C 89 44 24 ?? 57 48 83 EC ?? 48 8B DA 48 8B F9 45 85 C0";
 
+	// FHttpConnection::ProcessRequest(FHttpConnection* this, TSharedPtr<FHttpServerRequest> request,
+	//   TFunction<void(TUniquePtr<FHttpServerResponse>&&)> onComplete)
+	// Used only on server builds; defined unconditionally so it compiles on all configs.
+	// Confirmed offsets inside FHttpServerRequest (verified experimentally):
+	// obj+0   : HTTP verb  FString { wchar_t* Data @+0,  int32 Num @+8  }
+	//   obj+16  : RelativePath FString { wchar_t* Data @+16, int32 Num @+24 }
+	//   obj+280 : Body TArray<uint8> { uint8* Data @+280, int32 Num @+288 }
+	inline constexpr auto FHttpConnection_ProcessRequest =
+		"48 89 5C 24 ?? 55 56 41 54 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 83 79";
+
 #if defined(MODLOADER_CLIENT_BUILD)
 	inline constexpr const char* UGameEngine_Tick =
 		"40 55 53 56 41 54 41 56 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 0F 29 BC 24 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 ?? 0F 29 B4 24";
@@ -104,4 +114,10 @@ namespace ScanPatterns
 	// TODO: fill pattern via IDA/x64dbg — leave empty until found (hook will no-op gracefully)
 	inline constexpr auto AMassSpawner_DoSpawning =
 		"40 55 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ?? 48 8B F9 75";
+
+	// FHttpServerResponse::Create(__int64 *retStorage, const TArray<uint8>& body, const FString& contentType)
+	// Used to construct a 200 OK response for mod-owned HTTP routes.
+	// Confirmed via IDA: FPerfCounters::ProcessStatsRequest calls this with body in RDX, FString in R8.
+	inline constexpr auto FHttpServerResponse_Create =
+		"48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 ?? 48 8B F9 4D 8B E0";
 }

--- a/Version_Mod_Loader/hooks/hooks_interface.cpp
+++ b/Version_Mod_Loader/hooks/hooks_interface.cpp
@@ -19,6 +19,9 @@
 #include "hooks/game/mass_do_spawning/mass_do_spawning.h"
 #include "memory_scanner/scanner.h"
 #include "hooks/game/scan_patterns.h"
+#ifdef MODLOADER_SERVER_BUILD
+#include "hooks/http/http_server_hook.h"
+#endif
 #ifdef MODLOADER_CLIENT_BUILD
 #include "hooks/input/keybind_registry.h"
 #include "hooks/input/input_processor.h"
@@ -857,6 +860,70 @@ namespace ModLoaderLogger
 #endif
 	};
 
+	// -----------------------------------------------------------------------
+	// IPluginHttpServer wrappers (v22, server only)
+	// -----------------------------------------------------------------------
+
+#ifdef MODLOADER_SERVER_BUILD
+	static bool HooksHttpServerAddRoute(const IPluginSelf* self, const char* folderName)
+	{
+		if (!self || !self->name || !folderName)
+		{
+			LogWarn(L"[HooksInterface] HttpServer::AddRoute: null argument");
+			return false;
+		}
+		return Hooks::HttpServer::AddRoute(self->name, folderName);
+	}
+
+	static void HooksHttpServerRemoveRoute(const IPluginSelf* self, const char* folderName)
+	{
+		if (!self || !self->name || !folderName) return;
+		Hooks::HttpServer::RemoveRoute(self->name, folderName);
+	}
+
+	static void HooksHttpServerRegisterOnRawRequest(PluginHttpRequestFilterCallback callback)
+	{
+		if (!callback)
+		{
+			LogWarn(L"[HooksInterface] HttpServer::RegisterOnRawRequest: null callback");
+			return;
+		}
+		Hooks::HttpServer::RegisterRawRequestFilter(callback);
+	}
+
+	static void HooksHttpServerUnregisterOnRawRequest(PluginHttpRequestFilterCallback callback)
+	{
+		if (!callback) return;
+		Hooks::HttpServer::UnregisterRawRequestFilter(callback);
+	}
+
+	static bool HooksHttpServerAddRawRoute(const IPluginSelf* self, const char* urlPrefix,
+	      PluginHttpRouteCallback callback)
+	{
+		if (!self || !self->name || !urlPrefix || !callback)
+		{
+			LogWarn(L"[HooksInterface] HttpServer::AddRawRoute: null argument");
+			return false;
+		}
+		return Hooks::HttpServer::AddRawRoute(self->name, urlPrefix, callback);
+	}
+
+	static void HooksHttpServerRemoveRawRoute(const IPluginSelf* self, const char* urlPrefix)
+	{
+		if (!self || !self->name || !urlPrefix) return;
+		Hooks::HttpServer::RemoveRawRoute(self->name, urlPrefix);
+	}
+
+	static IPluginHttpServer g_httpServer = {
+		HooksHttpServerAddRoute,
+		HooksHttpServerRemoveRoute,
+		HooksHttpServerRegisterOnRawRequest,
+		HooksHttpServerUnregisterOnRawRequest,
+		HooksHttpServerAddRawRoute,
+		HooksHttpServerRemoveRawRoute,
+	};
+#endif // MODLOADER_SERVER_BUILD
+
 	// Global hooks interface instance
 	static IPluginHooks g_pluginHooks = {
 		&g_spawnerHooks,
@@ -873,10 +940,15 @@ namespace ModLoaderLogger
 #else
 		nullptr,          // v15 — Input is null on server/generic builds
 		nullptr,             // v15 — UI is null on server/generic builds
-		nullptr,       // v16 — HUD is null on server/generic builds
+		nullptr,    // v16 — HUD is null on server/generic builds
 #endif
-		nullptr,             // v17 — Network; filled in below by GetPluginHooks()
-		&g_nativePointers    // v21 — trampoline addresses for all managed hooks
+		nullptr,      // v17 — Network; filled in below by GetPluginHooks()
+		&g_nativePointers,   // v21 — trampoline addresses for all managed hooks
+#ifdef MODLOADER_SERVER_BUILD
+		&g_httpServer // v22 — HTTP static-file routes + raw-request filters (server only)
+#else
+		nullptr       // v22 — HttpServer is null on client/generic builds
+#endif
 	};
 	static bool g_networkChannelInitialized = false;
 

--- a/Version_Mod_Loader/hooks/http/http_server_hook.cpp
+++ b/Version_Mod_Loader/hooks/http/http_server_hook.cpp
@@ -1,0 +1,1332 @@
+#include "pch.h"
+#include "http_server_hook.h"
+
+#include "hooks/hooks_common.h"
+#include "logging/logger.h"
+#include "memory_scanner/scanner.h"
+#include "hooks/memory/engine_allocator.h"
+#include "hooks/game/scan_patterns.h"
+
+#include <Windows.h>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <algorithm>
+#include <mutex>
+#include <cwchar>
+#include <filesystem>
+#include <fstream>
+
+namespace Hooks::HttpServer
+{
+
+	// ---------------------------------------------------------------------------
+	// FHttpConnection::ProcessRequest — see ScanPatterns::FHttpConnection_ProcessRequest
+	//
+	// Signature (from IDA):
+	//   void __fastcall FHttpConnection::ProcessRequest(__int64 a1, _QWORD *a2, __int64 a3)
+	// a2  : TSharedPtr<FHttpServerRequest> — *a2 is the raw request pointer.
+	// a3  : TFunction<void(TUniquePtr<FHttpServerResponse>&&)> — response callback.
+	//
+	// Confirmed FHttpServerRequest offsets (verified experimentally):
+	//   obj+0   : HTTP verb  FString { wchar_t* Data @+0,  int32 Num @+8  }
+	//   obj+16  : RelativePath FString { wchar_t* Data @+16, int32 Num @+24 }
+	//   obj+280 : Body TArray<uint8> { uint8* Data @+280, int32 Num @+288 }
+	// ---------------------------------------------------------------------------
+
+	static constexpr size_t k_VerbOffset = 0;
+	static constexpr size_t k_UrlOffset = 16;
+	static constexpr size_t k_BodyOffset = 280;
+
+	// ---------------------------------------------------------------------------
+	// Hook state
+	// ---------------------------------------------------------------------------
+	using ProcessRequest_t = void(__fastcall*)(__int64 a1, uint64_t* a2, __int64 a3);
+	static ProcessRequest_t g_original = nullptr;
+	static Hooks::Hook      g_hook;
+
+	// FHttpServerResponse::Error — found by scanning ProcessRequest for mov edx, 404 + CALL
+	using FHttpServerResponseError_t = void(__fastcall*)(void** outPtr, int32_t code, void* errCode, void* errMsg);
+	static uintptr_t g_errorFuncAddr = 0;
+
+	// FHttpServerResponse::Create — confirmed via IDA (FPerfCounters::ProcessStatsRequest usage).
+	// Signature (actual ABI, MSVC x64):
+	//   __int64* __fastcall Create(__int64* retStorage,  // RCX — hidden return-value ptr
+	//       const FString& body,  // RDX — body as FString (UTF-16)
+	//    const FString& contentType) // R8 — content-type FString
+	// Both body and content-type are FString (wchar_t*, int32 Num, int32 Max).
+	using FHttpServerResponseCreate_t = void(__fastcall*)(__int64* retStorage,
+		void* body,
+		void* contentType);
+	static uintptr_t g_createFuncAddr = 0;
+
+	// ---------------------------------------------------------------------------
+	// Route registry
+	// ---------------------------------------------------------------------------
+	struct RouteEntry
+	{
+		std::string  pluginName; // original casing (for logging)
+		std::string  folderName; // original casing (for logging)
+		std::wstring fsRoot;     // absolute path on disk: <exe_dir>\Plugins\<pluginName>\<folderName>
+		std::string  urlPrefix;  // lowercased, no /plugins/ prefix: "/<pluginName>/<FolderName>/"
+	};
+
+	static std::vector<RouteEntry> g_routes;
+	static std::mutex g_routesMutex;
+
+	// ---------------------------------------------------------------------------
+	// Raw-response route registry (v22)
+	/// SEH-only trampoline — no C++ objects in scope so __try is legal.
+	/// Calls the plugin's route callback; on exception signals a 500 should be sent.
+	// ---------------------------------------------------------------------------
+
+	struct RawRouteEntry
+	{
+		std::string pluginName; // original casing (for logging)
+		std::string urlPrefix;  // lowercased: "/<pluginName>/<urlPrefix>/"
+		PluginHttpRouteCallback callback;
+	};
+
+	static std::vector<RawRouteEntry> g_rawRoutes;
+	static std::mutex g_rawRoutesMutex;
+
+	// ---------------------------------------------------------------------------
+	// Raw-request filter registry
+	// ---------------------------------------------------------------------------
+	static std::vector<PluginHttpRequestFilterCallback> g_filters;
+	static std::mutex g_filtersMutex;
+
+	// ---------------------------------------------------------------------------
+	// TFunction callback type helpers
+	// ---------------------------------------------------------------------------
+	using CallbackInvokeFn = void(__fastcall*)(__int64 callable, void** response);
+	using CallbackGetTargetFn = __int64(__fastcall*)(__int64 storage);
+
+	// ---------------------------------------------------------------------------
+	// FString / TArray mirror structs (must exactly match UE5 x64 layout)
+	// ---------------------------------------------------------------------------
+	struct FakeString
+	{
+		wchar_t* Data;
+		int32_t  Num;
+		int32_t  Max;
+	};
+
+	struct FakeByteArray
+	{
+		uint8_t* Data;
+		int32_t  Num;
+		int32_t  Max;
+	};
+
+	// ===========================================================================
+	// SEH-only helpers — plain functions, no C++ object unwinding, __try is legal.
+	// ===========================================================================
+
+	static bool IsReadableMemory(uintptr_t addr, size_t size)
+	{
+		if (!addr || !size) return false;
+		MEMORY_BASIC_INFORMATION mbi{};
+		if (!VirtualQuery(reinterpret_cast<LPCVOID>(addr), &mbi, sizeof(mbi))) return false;
+		if (mbi.State != MEM_COMMIT) return false;
+		if (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) return false;
+		return addr + size <= reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+	}
+
+	static size_t TryReadBytesSEH(uintptr_t addr, void* out, size_t n)
+	{
+		__try { memcpy(out, reinterpret_cast<const void*>(addr), n); return n; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+	}
+
+	static bool SetConnectionStateSEH(__int64 a1)
+	{
+		__try { *reinterpret_cast<int32_t*>(a1 + 24) = 2; return true; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+	}
+
+	static bool InvokeResponseCallbackSEH(__int64 a3, void** response)
+	{
+		__try
+		{
+			CallbackInvokeFn invoke = *reinterpret_cast<CallbackInvokeFn*>(a3);
+			__int64 storage = a3 + 16;
+			if (*reinterpret_cast<__int64*>(a3 + 40))
+				storage = *reinterpret_cast<__int64*>(a3 + 40);
+			__int64* vtable = *reinterpret_cast<__int64**>(storage);
+			auto getTarget = reinterpret_cast<CallbackGetTargetFn>(vtable[1]);
+			__int64 target = getTarget(storage);
+			invoke(target, response);
+			return true;
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+	}
+
+	static HttpRequestAction InvokeFilterSEH(PluginHttpRequestFilterCallback cb,
+		const PluginHttpRequest* req)
+	{
+		__try { return cb(req); }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return HttpRequestAction::Approve; }
+	}
+
+	// ===========================================================================
+	// Higher-level helpers — may use C++ objects
+	// ===========================================================================
+
+	static size_t TryReadBytes(uintptr_t addr, void* out, size_t len)
+	{
+		if (!IsReadableMemory(addr, 1)) return 0;
+		MEMORY_BASIC_INFORMATION mbi{};
+		if (!VirtualQuery(reinterpret_cast<LPCVOID>(addr), &mbi, sizeof(mbi))) return 0;
+		uintptr_t regionEnd = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+		size_t readable = (regionEnd > addr) ? (regionEnd - addr) : 0;
+		size_t n = len < readable ? len : readable;
+		return TryReadBytesSEH(addr, out, n);
+	}
+
+	static std::string ReadFStringUtf8Lower(uintptr_t req, size_t offset)
+	{
+		uintptr_t dataPtr = 0;
+		if (TryReadBytes(req + offset, &dataPtr, sizeof(dataPtr)) != sizeof(dataPtr) || !dataPtr)
+			return {};
+		std::vector<wchar_t> wbuf(512);
+		size_t got = TryReadBytes(dataPtr, wbuf.data(), wbuf.size() * sizeof(wchar_t));
+		size_t numChars = got / sizeof(wchar_t);
+		size_t len = 0;
+		while (len < numChars && wbuf[len]) ++len;
+		if (!len) return {};
+		for (size_t i = 0; i < len; ++i) wbuf[i] = static_cast<wchar_t>(towlower(wbuf[i]));
+		int needed = WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), nullptr, 0, nullptr, nullptr);
+		if (needed <= 0) return {};
+		std::string out(needed, '\0');
+		WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), &out[0], needed, nullptr, nullptr);
+		return out;
+	}
+
+	static std::string ReadFStringUtf8(uintptr_t req, size_t offset)
+	{
+		uintptr_t dataPtr = 0;
+		if (TryReadBytes(req + offset, &dataPtr, sizeof(dataPtr)) != sizeof(dataPtr) || !dataPtr)
+			return {};
+		std::vector<wchar_t> wbuf(512);
+	 size_t got = TryReadBytes(dataPtr, wbuf.data(), wbuf.size() * sizeof(wchar_t));
+		size_t numChars = got / sizeof(wchar_t);
+		size_t len = 0;
+		while (len < numChars && wbuf[len]) ++len;
+		if (!len) return {};
+		int needed = WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), nullptr, 0, nullptr, nullptr);
+		if (needed <= 0) return {};
+		std::string out(needed, '\0');
+		WideCharToMultiByte(CP_UTF8, 0, wbuf.data(), static_cast<int>(len), &out[0], needed, nullptr, nullptr);
+		return out;
+	}
+
+	static std::string ReadByteArray(uintptr_t req, size_t offset)
+	{
+		uintptr_t dataPtr = 0;
+		if (TryReadBytes(req + offset, &dataPtr, sizeof(dataPtr)) != sizeof(dataPtr) || !dataPtr)
+			return {};
+		int32_t num = 0;
+		if (TryReadBytes(req + offset + 8, &num, sizeof(num)) != sizeof(num) ||
+			num <= 0 || num > 16 * 1024 * 1024)
+			return {};
+		if (!IsReadableMemory(dataPtr, static_cast<size_t>(num))) return {};
+		std::string out(static_cast<size_t>(num), '\0');
+		if (TryReadBytes(dataPtr, &out[0], static_cast<size_t>(num)) != static_cast<size_t>(num))
+			return {};
+		return out;
+	}
+
+	static HttpMethod ParseVerb(const std::string& v)
+	{
+		if (v == "get")     return HttpMethod::Get;
+		if (v == "post")    return HttpMethod::Post;
+		if (v == "put")     return HttpMethod::Put;
+		if (v == "delete")  return HttpMethod::Delete;
+		if (v == "patch")   return HttpMethod::Patch;
+		if (v == "options") return HttpMethod::Options;
+		if (v == "head")    return HttpMethod::Head;
+		return HttpMethod::Other;
+	}
+
+	static uintptr_t FindErrorFunction(uintptr_t processRequestAddr)
+	{
+		uint8_t buf[4096] = {};
+		size_t got = TryReadBytes(processRequestAddr, buf, sizeof(buf));
+		if (got < 16) return 0;
+
+		// BA 94 01 00 00 = mov edx, 194h (404)
+		static const uint8_t kMov404[] = { 0xBA, 0x94, 0x01, 0x00, 0x00 };
+
+		for (size_t i = 0; i + 40 < got; ++i)
+		{
+			if (memcmp(buf + i, kMov404, sizeof(kMov404)) != 0)
+				continue;
+
+			// Scan forward up to 40 bytes for a direct relative CALL (E8 xx xx xx xx)
+			for (size_t j = i + sizeof(kMov404); j + 5 <= got && j < i + 40; ++j)
+			{
+				if (buf[j] != 0xE8)
+					continue;
+
+				int32_t rel = 0;
+				memcpy(&rel, buf + j + 1, sizeof(rel));
+				uintptr_t target = processRequestAddr + j + 5 + static_cast<intptr_t>(rel);
+
+				if (IsReadableMemory(target, 16))
+					return target;
+			}
+		}
+		return 0;
+	}
+
+	// ---------------------------------------------------------------------------
+	// FindCreateFunction — direct pattern scan for FHttpServerResponse::Create.
+	// Falls back to the heuristic scan of ProcessRequest if the pattern is not
+	// found (e.g. on a game update before the pattern is refreshed).
+	// ---------------------------------------------------------------------------
+	static uintptr_t FindCreateFunction(uintptr_t processRequestAddr, uintptr_t errorFuncAddr)
+	{
+		// Primary: direct pattern scan — most reliable.
+		uintptr_t direct = Scanner::FindPatternInMainModule(
+			"FHttpServerResponse::Create", ScanPatterns::FHttpServerResponse_Create);
+		if (direct)
+		{
+			ModLoaderLogger::LogDebug(L"[HttpServer] FindCreateFunction: found via direct pattern scan at 0x%llX",
+				static_cast<unsigned long long>(direct));
+			return direct;
+		}
+		ModLoaderLogger::LogWarn(L"[HttpServer] FindCreateFunction: direct pattern scan failed, trying heuristics");
+
+		// Fallback Strategy A: scan ProcessRequest for "mov edx, 0C8h" (200) + nearby E8 CALL.
+		uint8_t buf[8192] = {};
+		size_t got = TryReadBytes(processRequestAddr, buf, sizeof(buf));
+		if (got < 16) return 0;
+
+		static const uint8_t kMov200[] = { 0xBA, 0xC8, 0x00, 0x00, 0x00 };
+		for (size_t i = 0; i + 40 < got; ++i)
+		{
+			if (memcmp(buf + i, kMov200, sizeof(kMov200)) != 0) continue;
+			for (size_t j = i + sizeof(kMov200); j + 5 <= got && j < i + 40; ++j)
+			{
+				if (buf[j] != 0xE8) continue;
+				int32_t rel = 0;
+				memcpy(&rel, buf + j + 1, sizeof(rel));
+				uintptr_t target = processRequestAddr + j + 5 + static_cast<intptr_t>(rel);
+				if (target == errorFuncAddr || !IsReadableMemory(target, 16)) continue;
+				ModLoaderLogger::LogDebug(L"[HttpServer] FindCreateFunction: found via Strategy A at 0x%llX",
+					static_cast<unsigned long long>(target));
+				return target;
+			}
+		}
+
+		// Fallback Strategy B: proximity to Error + prologue filter.
+		if (!errorFuncAddr) return 0;
+		static constexpr uintptr_t kProximityWindow = 512 * 1024;
+		for (size_t i = 0; i + 5 <= got; ++i)
+		{
+			if (buf[i] != 0xE8) continue;
+			int32_t rel = 0;
+			memcpy(&rel, buf + i + 1, sizeof(rel));
+			uintptr_t target = processRequestAddr + i + 5 + static_cast<intptr_t>(rel);
+			if (target == errorFuncAddr || !IsReadableMemory(target, 16)) continue;
+			uintptr_t dist = (target > errorFuncAddr) ? (target - errorFuncAddr) : (errorFuncAddr - target);
+			if (dist > kProximityWindow) continue;
+			uint8_t prologue[5] = {};
+			if (TryReadBytes(target, prologue, 5) == 5 &&
+				prologue[0] == 0xBA && prologue[2] == 0x00 && prologue[3] == 0x00 && prologue[4] == 0x00)
+				continue;
+			ModLoaderLogger::LogDebug(L"[HttpServer] FindCreateFunction: found via Strategy B at 0x%llX",
+				static_cast<unsigned long long>(target));
+			return target;
+		}
+		return 0;
+	}
+
+	static void InvokeResponseCallback(__int64 a3, void** response)
+	{
+		if (!InvokeResponseCallbackSEH(a3, response))
+			ModLoaderLogger::LogError(L"[HttpServer] Exception invoking response callback");
+	}
+
+	// Returns true for MIME types whose body bytes must NOT be round-tripped
+	// through UTF-16.  MultiByteToWideChar corrupts arbitrary binary data.
+	static bool IsBinaryMimeType(const wchar_t* mime)
+	{
+		if (!mime) return true;
+		// Text types can safely pass through FString (UTF-16 round-trip).
+		// Everything else (images, binary formats, wasm, etc.) is opaque binary.
+		return !(wcsncmp(mime, L"text/", 5) == 0 ||
+			wcscmp(mime, L"application/javascript") == 0 ||
+			wcscmp(mime, L"application/json") == 0 ||
+			wcscmp(mime, L"image/svg+xml") == 0);
+	}
+
+	// Offset of the TArray<uint8> Body field inside FHttpServerResponse.
+	// UE5 layout (x64): Code(int32)@0, Headers(TMap)@8 (0x50 bytes), Body@0x58.
+	// Verified experimentally: Create() with an empty FString body leaves
+	// Body.Data==null and Body.Num==0 at this offset.
+	static constexpr size_t k_ResponseBodyOffset = 0x58;
+
+	static void SendBlockedResponse(__int64 a1, __int64 a3)
+	{
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendBlockedResponse: building 403 response");
+		if (!g_errorFuncAddr)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Error not located — dropping connection");
+			return;
+		}
+		if (!EngineAllocator::IsAvailable())
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] Engine allocator unavailable — dropping connection");
+			return;
+		}
+
+		static constexpr wchar_t kErrCode[] = L"errors.com.epicgames.httpserver.forbidden";
+		static constexpr int32_t kErrCodeChars = static_cast<int32_t>(sizeof(kErrCode) / sizeof(wchar_t));
+
+		auto errData = static_cast<wchar_t*>(EngineAllocator::Alloc(sizeof(kErrCode), 4));
+		if (!errData) { ModLoaderLogger::LogWarn(L"[HttpServer] EngineAlloc failed — dropping connection"); return; }
+		memcpy(errData, kErrCode, sizeof(kErrCode));
+
+		FakeString errCodeStr = { errData, kErrCodeChars - 1, kErrCodeChars };
+		FakeString emptyStr = { nullptr, 0, 0 };
+
+		void* response = nullptr;
+		reinterpret_cast<FHttpServerResponseError_t>(g_errorFuncAddr)(&response, 403, &errCodeStr, &emptyStr);
+		if (errCodeStr.Data) EngineAllocator::Free(errCodeStr.Data);
+
+		if (!response)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Error returned null — dropping connection");
+			return;
+		}
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendBlockedResponse: FHttpServerResponse::Error returned response=0x%p, setting connection state", response);
+		if (!SetConnectionStateSEH(a1))
+		{
+			ModLoaderLogger::LogError(L"[HttpServer] Failed to set connection state for 403");
+			return;
+		}
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendBlockedResponse: invoking response callback (403)");
+		InvokeResponseCallback(a3, &response);
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendBlockedResponse: done");
+	}
+
+	static void SendFileResponse(__int64 a1, __int64 a3,
+		const std::vector<uint8_t>& body, const wchar_t* contentType)
+	{
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse: body=%zu bytes, content-type=%s", body.size(), contentType);
+		if (!g_createFuncAddr)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Create not located — cannot serve file");
+			return;
+		}
+		if (!EngineAllocator::IsAvailable())
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] Engine allocator unavailable — cannot serve file");
+			return;
+		}
+
+		// Content-type FString (always needed).
+		const size_t ctLen = wcslen(contentType) + 1;
+		wchar_t* ctData = static_cast<wchar_t*>(EngineAllocator::Alloc(ctLen * sizeof(wchar_t), 4));
+		if (!ctData) { ModLoaderLogger::LogWarn(L"[HttpServer] EngineAlloc for content-type failed"); return; }
+		memcpy(ctData, contentType, ctLen * sizeof(wchar_t));
+		FakeString ctStr = { ctData, static_cast<int32_t>(ctLen), static_cast<int32_t>(ctLen) };
+
+		if (IsBinaryMimeType(contentType))
+		{
+			// ---------------------------------------------------------------
+			// Binary path: call Create with an empty body FString, then write
+			// the raw bytes directly into the response object's Body TArray.
+			// This avoids the MultiByteToWideChar round-trip that corrupts
+			// arbitrary binary data (PNG, JPEG, WASM, etc.).
+			// ---------------------------------------------------------------
+			FakeString emptyBody = { nullptr, 0, 0 };
+
+			void* responseStorage = nullptr;
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (binary): calling Create with empty body (0x%llX)",
+				static_cast<unsigned long long>(g_createFuncAddr));
+			reinterpret_cast<FHttpServerResponseCreate_t>(g_createFuncAddr)(
+				reinterpret_cast<__int64*>(&responseStorage), &emptyBody, &ctStr);
+			EngineAllocator::Free(ctData);
+
+			if (!responseStorage)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Create returned null (binary path)");
+				return;
+			}
+
+			// Patch Body TArray<uint8> in-place with the raw file bytes.
+			if (!body.empty())
+			{
+				uint8_t* rawData = static_cast<uint8_t*>(EngineAllocator::Alloc(body.size(), 1));
+				if (!rawData)
+				{
+					ModLoaderLogger::LogWarn(L"[HttpServer] EngineAlloc for binary body failed (%zu bytes)", body.size());
+					// Fall through — response will have an empty body but correct status/content-type.
+				}
+				else
+				{
+					memcpy(rawData, body.data(), body.size());
+					// Write directly into the response object's TArray<uint8> Body field.
+					auto* bodyArray = reinterpret_cast<FakeByteArray*>(
+						reinterpret_cast<uint8_t*>(responseStorage) + k_ResponseBodyOffset);
+					bodyArray->Data = rawData;
+					bodyArray->Num  = static_cast<int32_t>(body.size());
+					bodyArray->Max  = static_cast<int32_t>(body.size());
+					ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (binary): patched Body TArray: Data=%p Num=%d",
+						rawData, bodyArray->Num);
+				}
+			}
+
+			void* response = responseStorage;
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (binary): response=0x%p, setting connection state", response);
+			if (!SetConnectionStateSEH(a1))
+			{
+				ModLoaderLogger::LogError(L"[HttpServer] Failed to set connection state for 200 (binary)");
+				return;
+			}
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (binary): invoking response callback");
+			InvokeResponseCallback(a3, &response);
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (binary): done");
+		}
+		else
+		{
+			// ---------------------------------------------------------------
+			// Text path: convert body bytes (UTF-8) to UTF-16 for FString.
+			// Safe for HTML, CSS, JS, JSON, SVG, plain text.
+			// ---------------------------------------------------------------
+			int bodyWideLen = 0;
+			wchar_t* bodyData = nullptr;
+			if (!body.empty())
+			{
+				bodyWideLen = MultiByteToWideChar(CP_UTF8, 0,
+					reinterpret_cast<const char*>(body.data()), static_cast<int>(body.size()),
+					nullptr, 0);
+				if (bodyWideLen > 0)
+				{
+					bodyData = static_cast<wchar_t*>(EngineAllocator::Alloc(
+						static_cast<size_t>(bodyWideLen + 1) * sizeof(wchar_t), 4));
+					if (!bodyData) { EngineAllocator::Free(ctData); ModLoaderLogger::LogWarn(L"[HttpServer] EngineAlloc for body failed"); return; }
+					MultiByteToWideChar(CP_UTF8, 0,
+						reinterpret_cast<const char*>(body.data()), static_cast<int>(body.size()),
+						bodyData, bodyWideLen);
+					bodyData[bodyWideLen] = L'\0';
+				}
+				else bodyWideLen = 0;
+				ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (text): body wide len=%d, allocated at 0x%p", bodyWideLen, bodyData);
+			}
+
+			const int32_t bodyNum = bodyData ? (bodyWideLen + 1) : 0;
+			FakeString bodyStr = { bodyData, bodyNum, bodyNum };
+
+			void* responseStorage = nullptr;
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (text): calling FHttpServerResponse::Create (0x%llX)",
+				static_cast<unsigned long long>(g_createFuncAddr));
+			reinterpret_cast<FHttpServerResponseCreate_t>(g_createFuncAddr)(
+				reinterpret_cast<__int64*>(&responseStorage), &bodyStr, &ctStr);
+			if (ctData)   EngineAllocator::Free(ctData);
+			if (bodyData) EngineAllocator::Free(bodyData);
+
+			void* response = responseStorage;
+			if (!response)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Create returned null — cannot serve file");
+				return;
+			}
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (text): Create returned response=0x%p, setting connection state", response);
+			if (!SetConnectionStateSEH(a1))
+			{
+				ModLoaderLogger::LogError(L"[HttpServer] Failed to set connection state for 200");
+				return;
+			}
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (text): invoking response callback (200)");
+			InvokeResponseCallback(a3, &response);
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendFileResponse (text): done");
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Send an arbitrary response via FHttpServerResponse::Create / Error
+	// Used by raw-response routes so the plugin doesn't need its own response construction.
+	// ---------------------------------------------------------------------------
+	static void SendRawResponse(__int64 a1, __int64 a3,
+		int statusCode, const char* contentType,
+		const char* body, size_t bodyLen)
+	{
+		if (!contentType || !contentType[0]) contentType = "text/plain";
+		if (!body) bodyLen = 0;
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: status=%d content-type=%S body_len=%zu",
+			statusCode, contentType, bodyLen);
+
+		if (statusCode != 200)
+		{
+			if (!g_errorFuncAddr)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: FHttpServerResponse::Error not located, dropping");
+				return;
+			}
+			if (!EngineAllocator::IsAvailable())
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: allocator unavailable, dropping");
+				return;
+			}
+
+			char codeStr[32]{};
+			snprintf(codeStr, sizeof(codeStr), "errors.com.epicgames.httpserver.%d", statusCode);
+			wchar_t wCodeStr[64]{};
+			int wLen = MultiByteToWideChar(CP_UTF8, 0, codeStr, -1, wCodeStr, 64);
+			if (wLen <= 1) wLen = 1;
+
+			auto codeData = static_cast<wchar_t*>(EngineAllocator::Alloc(wLen * sizeof(wchar_t), 4));
+			if (!codeData) return;
+			memcpy(codeData, wCodeStr, wLen * sizeof(wchar_t));
+
+			FakeString codeFs = { codeData, wLen - 1, wLen };
+			FakeString emptyFs = { nullptr, 0, 0 };
+
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: calling FHttpServerResponse::Error (0x%llX), code=%S",
+				static_cast<unsigned long long>(g_errorFuncAddr), wCodeStr);
+			void* response = nullptr;
+			reinterpret_cast<FHttpServerResponseError_t>(g_errorFuncAddr)(
+				&response, statusCode, &codeFs, &emptyFs);
+			EngineAllocator::Free(codeData);
+
+			if (!response)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: FHttpServerResponse::Error returned null, dropping");
+				return;
+			}
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: error response=0x%p, setting state + invoking callback", response);
+			if (!SetConnectionStateSEH(a1)) return;
+			InvokeResponseCallback(a3, &response);
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: done (error path)");
+			return;
+		}
+
+		// --- 200 OK path ---
+		if (!g_createFuncAddr)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: FHttpServerResponse::Create not located, dropping");
+			return;
+		}
+		if (!EngineAllocator::IsAvailable())
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: allocator unavailable, dropping");
+			return;
+		}
+
+		// Create takes FString* for body — convert UTF-8 body bytes to UTF-16.
+		wchar_t* bodyData = nullptr;
+		if (bodyLen > 0)
+		{
+			int bodyWideLen = MultiByteToWideChar(CP_UTF8, 0, body, static_cast<int>(bodyLen), nullptr, 0);
+			if (bodyWideLen > 0)
+			{
+				bodyData = static_cast<wchar_t*>(EngineAllocator::Alloc(
+					static_cast<size_t>(bodyWideLen + 1) * sizeof(wchar_t), 4));
+				if (!bodyData) return;
+				MultiByteToWideChar(CP_UTF8, 0, body, static_cast<int>(bodyLen), bodyData, bodyWideLen);
+				bodyData[bodyWideLen] = L'\0';
+			}
+			ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: body wide len=%d allocated at 0x%p", bodyWideLen, bodyData);
+		}
+
+		// Content-type (wide)
+		int ctNeeded = MultiByteToWideChar(CP_UTF8, 0, contentType, -1, nullptr, 0);
+		if (ctNeeded <= 0) ctNeeded = 1;
+		auto ctData = static_cast<wchar_t*>(EngineAllocator::Alloc(static_cast<size_t>(ctNeeded) * sizeof(wchar_t), 4));
+		if (!ctData) { if (bodyData) EngineAllocator::Free(bodyData); return; }
+		MultiByteToWideChar(CP_UTF8, 0, contentType, -1, ctData, ctNeeded);
+
+		// FString::Num includes the null terminator. Num=0 when Data is null.
+		const int32_t bodyNum = bodyData ? (static_cast<int32_t>(bodyLen) + 1) : 0;
+		FakeString bodyFs = { bodyData, bodyNum,   bodyNum };
+		FakeString ctFs = { ctData,   ctNeeded,  ctNeeded };
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: calling FHttpServerResponse::Create (0x%llX)",
+			static_cast<unsigned long long>(g_createFuncAddr));
+		void* response = nullptr;
+		reinterpret_cast<FHttpServerResponseCreate_t>(g_createFuncAddr)(
+			reinterpret_cast<__int64*>(&response), &bodyFs, &ctFs);
+		EngineAllocator::Free(ctData);
+		if (bodyData) EngineAllocator::Free(bodyData);
+
+		if (!response)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] SendRawResponse: FHttpServerResponse::Create returned null, dropping");
+			return;
+		}
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: ok response=0x%p, setting state + invoking callback", response);
+		if (!SetConnectionStateSEH(a1)) return;
+		InvokeResponseCallback(a3, &response);
+		ModLoaderLogger::LogTrace(L"[HttpServer] SendRawResponse: done (ok path)");
+	}
+
+	// ---------------------------------------------------------------------------
+	// MIME type table
+	// ---------------------------------------------------------------------------
+	static const wchar_t* GetMimeType(std::wstring_view ext)
+	{
+		if (ext == L".html" || ext == L".htm") return L"text/html";
+		if (ext == L".css")return L"text/css";
+		if (ext == L".js")   return L"application/javascript";
+		if (ext == L".json") return L"application/json";
+		if (ext == L".png")  return L"image/png";
+		if (ext == L".jpg" || ext == L".jpeg") return L"image/jpeg";
+		if (ext == L".gif")  return L"image/gif";
+		if (ext == L".svg")  return L"image/svg+xml";
+		if (ext == L".ico")  return L"image/x-icon";
+		if (ext == L".wasm") return L"application/wasm";
+		if (ext == L".txt")  return L"text/plain";
+		if (ext == L".xml")  return L"text/xml";
+		return L"application/octet-stream";
+	}
+
+	// ---------------------------------------------------------------------------
+	// Path safety
+	// ---------------------------------------------------------------------------
+	static bool IsSafeUrlPath(std::string_view path)
+	{
+		if (path.find("..") != std::string_view::npos) return false;
+		if (path.find('\\') != std::string_view::npos) return false;
+		return true;
+	}
+
+	static std::string UrlDecode(std::string_view in)
+	{
+		std::string out;
+		out.reserve(in.size());
+		for (size_t i = 0; i < in.size(); ++i)
+		{
+			if (in[i] == '%' && i + 2 < in.size())
+			{
+				auto hexVal = [](char c) -> int {
+					if (c >= '0' && c <= '9') return c - '0';
+					if (c >= 'a' && c <= 'f') return 10 + c - 'a';
+					if (c >= 'A' && c <= 'F') return 10 + c - 'A';
+					return -1;
+					};
+				int h = hexVal(in[i + 1]), l = hexVal(in[i + 2]);
+				if (h >= 0 && l >= 0) { out += static_cast<char>((h << 4) | l); i += 2; continue; }
+			}
+			out += in[i];
+		}
+		return out;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Static-file route dispatch — Phase 2b
+	// Returns true if the URL matched a route (served or blocked).
+	/// Returns false to let the original engine handler produce a 404.
+	// ---------------------------------------------------------------------------
+
+	// Default documents tried in order when the URL resolves to a directory.
+	static constexpr const char* k_DefaultDocs[] = { "index.html", "index.htm" };
+
+	static bool TryServeStaticFile(__int64 a1, __int64 a3, const std::string& urlLower)
+	{
+		std::lock_guard lock(g_routesMutex);
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] TryServeStaticFile: checking %zu registered static route(s) for url=%S",
+			g_routes.size(), urlLower.c_str());
+
+		for (const auto& route : g_routes)
+		{
+			ModLoaderLogger::LogTrace(L"[HttpServer]   static route check: url=%S prefix=%S",
+				urlLower.c_str(), route.urlPrefix.c_str());
+
+			if (urlLower.size() < route.urlPrefix.size()) continue;
+			if (urlLower.compare(0, route.urlPrefix.size(), route.urlPrefix) != 0) continue;
+
+			ModLoaderLogger::LogTrace(L"[HttpServer]   static route matched: prefix=%S plugin=%S folder=%S",
+				route.urlPrefix.c_str(), route.pluginName.c_str(), route.folderName.c_str());
+
+			std::string rel = UrlDecode(urlLower.substr(route.urlPrefix.size()));
+			// The trailing slash normalisation in Detour means urlLower always ends with '/'.
+			// After stripping the prefix, rel will end with '/' when the prefix is an exact
+			// match (directory request) or when the sub-path itself ends with '/'.
+			// Strip that trailing slash from rel so the path logic below is clean.
+			if (!rel.empty() && rel.back() == '/') rel.pop_back();
+
+			ModLoaderLogger::LogTrace(L"[HttpServer]   relative path after decode+trim: '%S'", rel.c_str());
+
+			if (!IsSafeUrlPath(rel))
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] Blocked path traversal attempt: %S", rel.c_str());
+				SendBlockedResponse(a1, a3);
+				return true;
+			}
+
+			// ---------------------------------------------------------------------------
+			// Determine whether this looks like a directory or a file request.
+			// A request is treated as a directory request (and triggers default-doc
+			// probing) when:
+			//   1. rel is empty           — bare prefix hit, e.g. /plugin/ui/
+			//   2. rel has no extension   — e.g. /plugin/ui/dashboard  (no dot after last '/')
+			// A request is treated as a direct file request otherwise.
+			// ---------------------------------------------------------------------------
+			auto IsDirectoryRequest = [](const std::string& r) -> bool
+				{
+					if (r.empty()) return true;
+					// r has already had its trailing slash stripped by the caller, so the last
+					// character is never '/'. Find the last path segment and check for a dot.
+					// A segment with a dot is treated as a file (e.g. "index.html", "app.js").
+					// A segment without a dot is treated as a directory (e.g. "dashboard", "").
+					auto lastSlash = r.rfind('/');
+					std::string_view lastSegment = (lastSlash == std::string::npos)
+						? std::string_view(r)
+						: std::string_view(r).substr(lastSlash + 1);
+					// If the last segment is empty (shouldn't happen after trimming, but be safe)
+					// or contains no dot, treat as directory.
+					return lastSegment.empty() || lastSegment.find('.') == std::string_view::npos;
+				};
+
+			const bool isDirRequest = IsDirectoryRequest(rel);
+			ModLoaderLogger::LogTrace(L"[HttpServer]   request type: %s", isDirRequest ? L"directory" : L"file");
+
+			// Helper: build, safety-check, and if valid return the resolved fs path.
+			// Returns an empty path on any safety violation (and sends 403 internally).
+			auto ResolvePath = [&](const std::string& relPath) -> std::filesystem::path
+				{
+					std::wstring wRel(relPath.begin(), relPath.end());
+					std::filesystem::path resolved = (std::filesystem::path(route.fsRoot) / wRel).lexically_normal();
+
+					auto rootNorm = std::filesystem::path(route.fsRoot).lexically_normal();
+					auto [rootEnd, _] = std::mismatch(rootNorm.begin(), rootNorm.end(),
+						resolved.begin(), resolved.end());
+					if (rootEnd != rootNorm.end())
+					{
+						ModLoaderLogger::LogWarn(L"[HttpServer] Path escaped route root, blocked: %s", resolved.c_str());
+						SendBlockedResponse(a1, a3);
+						return {};
+					}
+					return resolved;
+				};
+
+			// Helper: read and serve a resolved path. Returns true on success.
+			auto ServeFile = [&](const std::filesystem::path& fsPath) -> bool
+				{
+					ModLoaderLogger::LogTrace(L"[HttpServer]   opening file: %s", fsPath.c_str());
+
+					std::ifstream file(fsPath, std::ios::binary | std::ios::ate);
+					if (!file.is_open())
+					{
+						ModLoaderLogger::LogTrace(L"[HttpServer]   file not found: %s", fsPath.c_str());
+						return false;
+					}
+
+					std::streamsize size = file.tellg();
+					ModLoaderLogger::LogTrace(L"[HttpServer]   file opened, size=%lld bytes", static_cast<long long>(size));
+					file.seekg(0, std::ios::beg);
+
+					if (size < 0 || size > 32 * 1024 * 1024)
+					{
+						ModLoaderLogger::LogWarn(L"[HttpServer] File too large: %s", fsPath.c_str());
+						ModLoaderLogger::LogTrace(L"[HttpServer]   file size out of bounds (%lld), skipping", static_cast<long long>(size));
+						return false;
+					}
+
+					std::vector<uint8_t> body(static_cast<size_t>(size));
+					if (!file.read(reinterpret_cast<char*>(body.data()), size))
+					{
+						ModLoaderLogger::LogWarn(L"[HttpServer] Failed to read file: %s", fsPath.c_str());
+						ModLoaderLogger::LogTrace(L"[HttpServer]   file read failed, skipping");
+						return false;
+					}
+
+					const wchar_t* mime = GetMimeType(fsPath.extension().wstring());
+					ModLoaderLogger::LogDebug(L"[HttpServer] Serving %s (%zu bytes, %s)", fsPath.c_str(), body.size(), mime);
+					ModLoaderLogger::LogTrace(L"[HttpServer]   dispatching to SendFileResponse: %zu bytes, mime=%s", body.size(), mime);
+					SendFileResponse(a1, a3, body, mime);
+					ModLoaderLogger::LogTrace(L"[HttpServer]   SendFileResponse returned");
+					return true;
+				};
+
+			if (isDirRequest)
+			{
+				// Probe each default document in priority order.
+				ModLoaderLogger::LogTrace(L"[HttpServer]   directory request — probing default documents under '%S'",
+					rel.c_str());
+
+				for (const char* defaultDoc : k_DefaultDocs)
+				{
+					std::string candidate = rel.empty() ? defaultDoc : (rel + "/" + defaultDoc);
+					ModLoaderLogger::LogTrace(L"[HttpServer]   trying default doc: %S", candidate.c_str());
+
+					std::filesystem::path fsPath = ResolvePath(candidate);
+					if (fsPath.empty()) return true; // safety violation already handled (403 sent)
+
+					if (ServeFile(fsPath))
+					{
+						ModLoaderLogger::LogTrace(L"[HttpServer]   served default doc '%S', TryServeStaticFile done", defaultDoc);
+						return true;
+					}
+				}
+
+				// No default document found — fall through to let the engine produce a 404.
+				ModLoaderLogger::LogDebug(L"[HttpServer] No default document found under route %S for url=%S",
+					route.urlPrefix.c_str(), urlLower.c_str());
+				ModLoaderLogger::LogTrace(L"[HttpServer]   no default doc found, returning false");
+				return false;
+			}
+			else
+			{
+				// Direct file request — resolve and serve exactly what was asked for.
+				std::filesystem::path fsPath = ResolvePath(rel);
+				if (fsPath.empty()) return true; // 403 already sent
+
+				ModLoaderLogger::LogTrace(L"[HttpServer]   resolved fs path: %s", fsPath.c_str());
+
+				if (ServeFile(fsPath))
+				{
+					ModLoaderLogger::LogTrace(L"[HttpServer]   TryServeStaticFile done (direct file)");
+					return true;
+				}
+
+				// File genuinely not found — let the engine produce a 404.
+				ModLoaderLogger::LogDebug(L"[HttpServer] File not found: %s", fsPath.c_str());
+				ModLoaderLogger::LogTrace(L"[HttpServer]   file not found, returning false");
+				return false;
+			}
+		}
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] TryServeStaticFile: no static route matched url=%S", urlLower.c_str());
+		return false;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Raw-route dispatch — Phase 2a (runs before static-file Phase 2b)
+	// Returns true if a raw route matched (even if the callback left an empty body).
+	// ---------------------------------------------------------------------------
+
+	/// SEH-only trampoline — no C++ objects in scope so __try is legal.
+	/// Calls the plugin's route callback; on exception signals a 500 should be sent.
+	static bool InvokeRawRouteCallbackSEH(PluginHttpRouteCallback cb,
+		const PluginHttpRequest* req, PluginHttpResponse* resp)
+	{
+		__try { cb(req, resp); return true; }
+		__except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+	}
+
+	// NOTE: TryServeStaticFile is defined above — no forward declaration needed.
+
+	static bool TryDispatchRawRoute(__int64 a1, __int64 a3,
+		const std::string& urlLower,
+		const std::string& urlOrig,
+		const std::string& verbLower,
+		const std::string& bodyStr)
+	{
+		std::lock_guard lock(g_rawRoutesMutex);
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] TryDispatchRawRoute: checking %zu registered raw route(s) for url=%S",
+			g_rawRoutes.size(), urlLower.c_str());
+
+		for (const auto& route : g_rawRoutes)
+		{
+			ModLoaderLogger::LogTrace(L"[HttpServer]   raw route check: url=%S prefix=%S plugin=%S",
+				urlLower.c_str(), route.urlPrefix.c_str(), route.pluginName.c_str());
+
+			if (urlLower.size() < route.urlPrefix.size()) continue;
+			if (urlLower.compare(0, route.urlPrefix.size(), route.urlPrefix) != 0) continue;
+
+			ModLoaderLogger::LogDebug(L"[HttpServer] Raw route matched: %S -> %S",
+				urlOrig.c_str(), route.pluginName.c_str());
+			ModLoaderLogger::LogTrace(L"[HttpServer]   raw route matched: prefix=%S, invoking plugin callback",
+				route.urlPrefix.c_str());
+
+			PluginHttpRequest req{};
+			req.url = urlOrig.c_str();
+			req.body = bodyStr.empty() ? nullptr : bodyStr.c_str();
+			req.bodyLen = bodyStr.size();
+			req.method = ParseVerb(verbLower);
+
+			PluginHttpResponse resp{};
+			resp.statusCode = 200;
+			resp.contentType = "text/plain";
+			resp.body = nullptr;
+			resp.bodyLen = 0;
+
+			ModLoaderLogger::LogTrace(L"[HttpServer]   calling InvokeRawRouteCallbackSEH for prefix=%S",
+				route.urlPrefix.c_str());
+			if (!InvokeRawRouteCallbackSEH(route.callback, &req, &resp))
+			{
+				ModLoaderLogger::LogError(L"[HttpServer] Exception in raw-route callback for %S",
+					route.urlPrefix.c_str());
+				ModLoaderLogger::LogTrace(L"[HttpServer]   callback threw exception, sending 500");
+				SendRawResponse(a1, a3, 500, "text/plain", nullptr, 0);
+				return true;
+			}
+
+			ModLoaderLogger::LogTrace(L"[HttpServer]   callback returned: status=%d content-type=%S body_len=%zu",
+				resp.statusCode,
+				resp.contentType ? resp.contentType : "(null)",
+				resp.bodyLen);
+			// Modified to always use empty fsPath
+			SendRawResponse(a1, a3, resp.statusCode, resp.contentType, resp.body, resp.bodyLen);
+			ModLoaderLogger::LogTrace(L"[HttpServer]   TryDispatchRawRoute done for prefix=%S", route.urlPrefix.c_str());
+			return true;
+		}
+
+		ModLoaderLogger::LogTrace(L"[HttpServer] TryDispatchRawRoute: no raw route matched url=%S", urlLower.c_str());
+		return false;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Detour
+	// ---------------------------------------------------------------------------
+	static void __fastcall Detour(__int64 a1, uint64_t* a2, __int64 a3)
+	{
+		if (a2)
+		{
+			uint64_t p = 0;
+			if (TryReadBytes(reinterpret_cast<uintptr_t>(a2), &p, sizeof(p)) == sizeof(p) && p != 0)
+			{
+				std::string verbLower = ReadFStringUtf8Lower(p, k_VerbOffset);
+				std::string urlLower = ReadFStringUtf8Lower(p, k_UrlOffset);
+				std::string urlOrig = ReadFStringUtf8(p, k_UrlOffset);
+				std::string body = ReadByteArray(p, k_BodyOffset);
+
+				// Normalise: strip query-string / fragment, then ensure a trailing slash
+				// so that /foo/bar and /foo/bar/ both match the registered prefix /foo/bar/.
+				// Query strings and fragments are not part of the path and must be removed
+				// before prefix matching, otherwise /foo/bar?x=1 would never match /foo/bar/.
+				auto StripSuffix = [](std::string& s)
+					{
+						auto q = s.find('?');
+						if (q != std::string::npos) s.erase(q);
+						auto f = s.find('#');
+						if (f != std::string::npos) s.erase(f);
+						if (s.empty() || s.back() != '/') s += '/';
+					};
+				StripSuffix(urlLower);
+				// Apply the same normalisation to urlOrig (preserve original casing for logging,
+				// but strip query/fragment and add trailing slash for consistent logging).
+				{
+					auto q = urlOrig.find('?');
+					if (q != std::string::npos) urlOrig.erase(q);
+					auto f = urlOrig.find('#');
+					if (f != std::string::npos) urlOrig.erase(f);
+					if (urlOrig.empty() || urlOrig.back() != '/') urlOrig += '/';
+				}
+
+				ModLoaderLogger::LogTrace(L"[HttpServer] URL normalised: lower=%S orig=%S",
+					urlLower.c_str(), urlOrig.c_str());
+
+				// ---------------------------------------------------------------------------
+				// Trace: log every incoming HTTP request with full details
+				// ---------------------------------------------------------------------------
+				{
+					std::wstring wVerb(verbLower.begin(), verbLower.end());
+					std::wstring wUrl(urlOrig.begin(), urlOrig.end());
+
+					ModLoaderLogger::LogTrace(
+						L"[HttpServer] >> Incoming request: method=%s url=%s body_len=%zu a1=0x%llX a2=0x%llX a3=0x%llX",
+						wVerb.empty() ? L"(unknown)" : wVerb.c_str(),
+						wUrl.empty() ? L"(unknown)" : wUrl.c_str(),
+						body.size(),
+						static_cast<unsigned long long>(a1),
+						reinterpret_cast<unsigned long long>(a2),
+						static_cast<unsigned long long>(a3));
+
+					if (!body.empty())
+					{
+						// Log up to 512 bytes of body as UTF-8 (converted to wide for the logger).
+						// Truncate at the first embedded null so the string stays printable.
+						constexpr size_t kMaxBodyLog = 512;
+						size_t logLen = (std::min)(body.size(), kMaxBodyLog);
+						// Clamp at embedded null
+						size_t nullPos = body.find('\0');
+						if (nullPos != std::string::npos && nullPos < logLen) logLen = nullPos;
+
+						int wNeeded = MultiByteToWideChar(CP_UTF8, 0, body.c_str(), static_cast<int>(logLen), nullptr, 0);
+						if (wNeeded > 0)
+						{
+							std::wstring wBody(static_cast<size_t>(wNeeded), L'\0');
+							MultiByteToWideChar(CP_UTF8, 0, body.c_str(), static_cast<int>(logLen), wBody.data(), wNeeded);
+							ModLoaderLogger::LogTrace(L"[HttpServer]    body (first %zu bytes)%s: %s",
+								logLen,
+								body.size() > kMaxBodyLog ? L" [truncated]" : L"",
+								wBody.c_str());
+						}
+						else
+						{
+							ModLoaderLogger::LogTrace(L"[HttpServer]    body (%zu bytes, non-UTF-8 / binary)", body.size());
+						}
+					}
+					else
+					{
+						ModLoaderLogger::LogTrace(L"[HttpServer] body: (empty)");
+					}
+				}
+
+				// Phase 1: raw-request filters — first Deny wins
+				{
+					PluginHttpRequest req{};
+					req.url = urlOrig.c_str();
+					req.body = body.empty() ? nullptr : body.c_str();
+					req.bodyLen = body.size();
+					req.method = ParseVerb(verbLower);
+
+					std::lock_guard lock(g_filtersMutex);
+					ModLoaderLogger::LogTrace(L"[HttpServer] Phase 1: evaluating %zu filter(s)", g_filters.size());
+					size_t filterIdx = 0;
+					for (auto* cb : g_filters)
+					{
+						if (!cb) { ++filterIdx; continue; }
+						ModLoaderLogger::LogTrace(L"[HttpServer]   filter[%zu]: invoking for url=%S", filterIdx, urlOrig.c_str());
+						HttpRequestAction action = InvokeFilterSEH(cb, &req);
+						ModLoaderLogger::LogTrace(L"[HttpServer]   filter[%zu]: result=%s", filterIdx,
+							action == HttpRequestAction::Deny ? L"Deny" : L"Approve");
+						if (action == HttpRequestAction::Deny)
+						{
+							ModLoaderLogger::LogDebug(L"[HttpServer] Request denied by filter: %S", urlOrig.c_str());
+							ModLoaderLogger::LogTrace(L"[HttpServer]   filter[%zu] denied request, sending 403", filterIdx);
+							SendBlockedResponse(a1, a3);
+							return;
+						}
+						++filterIdx;
+					}
+					ModLoaderLogger::LogTrace(L"[HttpServer] Phase 1: all filters approved");
+				}
+
+				// Phase 2a: raw-response routes — plugin-owned handlers
+				ModLoaderLogger::LogTrace(L"[HttpServer] Phase 2a: dispatching to raw routes");
+				if (TryDispatchRawRoute(a1, a3, urlLower, urlOrig, verbLower, body))
+				{
+					ModLoaderLogger::LogTrace(L"[HttpServer] Phase 2a: raw route handled request, returning");
+					return;
+				}
+
+				// Phase 2b: static-file routes
+				ModLoaderLogger::LogTrace(L"[HttpServer] Phase 2b: dispatching to static-file routes");
+				if (TryServeStaticFile(a1, a3, urlLower))
+				{
+					ModLoaderLogger::LogTrace(L"[HttpServer] Phase 2b: static-file route handled request, returning");
+					return;
+				}
+
+				ModLoaderLogger::LogTrace(L"[HttpServer] Phase 2a+2b: no mod route matched, falling through to engine handler");
+			}
+		}
+
+		// Phase 3: original engine handler
+		ModLoaderLogger::LogTrace(L"[HttpServer] Phase 3: forwarding to original FHttpConnection::ProcessRequest (0x%llX)",
+			reinterpret_cast<unsigned long long>(g_original));
+		if (g_original) g_original(a1, a2, a3);
+		ModLoaderLogger::LogTrace(L"[HttpServer] Phase 3: original handler returned");
+	}
+
+	// ---------------------------------------------------------------------------
+	// Public API
+	// ---------------------------------------------------------------------------
+
+	bool Install()
+	{
+		if (g_hook.installed) return true;
+
+		ModLoaderLogger::LogInfo(L"[HttpServer] Scanning for FHttpConnection::ProcessRequest...");
+
+		uintptr_t addr = Scanner::FindPatternInMainModule(
+			"FHttpConnection::ProcessRequest", ScanPatterns::FHttpConnection_ProcessRequest);
+		if (!addr)
+		{
+			ModLoaderLogger::LogError(L"[HttpServer] Pattern scan failed — hook not installed");
+			return false;
+		}
+
+		auto base = reinterpret_cast<uintptr_t>(GetModuleHandleW(nullptr));
+		ModLoaderLogger::LogInfo(L"[HttpServer] Found FHttpConnection::ProcessRequest at 0x%llX (base+0x%llX)",
+			static_cast<unsigned long long>(addr),
+			static_cast<unsigned long long>(addr - base));
+
+		g_errorFuncAddr = FindErrorFunction(addr);
+		if (g_errorFuncAddr)
+			ModLoaderLogger::LogDebug(L"[HttpServer] Found FHttpServerResponse::Error at 0x%llX",
+				static_cast<unsigned long long>(g_errorFuncAddr));
+		else
+			ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Error not found — denied requests will drop the connection");
+
+		g_createFuncAddr = FindCreateFunction(addr, g_errorFuncAddr);
+		if (g_createFuncAddr)
+			ModLoaderLogger::LogDebug(L"[HttpServer] Found FHttpServerResponse::Create at 0x%llX",
+				static_cast<unsigned long long>(g_createFuncAddr));
+		else
+			ModLoaderLogger::LogWarn(L"[HttpServer] FHttpServerResponse::Create not found — HTTP OK responses will not function");
+
+		bool ok = g_hook.Install(addr, reinterpret_cast<void*>(&Detour), reinterpret_cast<void**>(&g_original));
+
+		if (ok) ModLoaderLogger::LogInfo(L"[HttpServer] Hook installed successfully");
+		else    ModLoaderLogger::LogError(L"[HttpServer] Hook installation failed");
+		return ok;
+	}
+
+	void Remove()
+	{
+		if (!g_hook.installed) return;
+
+		ModLoaderLogger::LogInfo(L"[HttpServer] Removing hook...");
+		g_hook.Remove();
+		g_original = nullptr; g_errorFuncAddr = 0; g_createFuncAddr = 0;
+		{ std::lock_guard lock(g_routesMutex);    g_routes.clear(); }
+		{ std::lock_guard lock(g_rawRoutesMutex); g_rawRoutes.clear(); }
+		{ std::lock_guard lock(g_filtersMutex);   g_filters.clear(); }
+		ModLoaderLogger::LogInfo(L"[HttpServer] Hook removed");
+	}
+
+	bool IsInstalled() { return g_hook.installed; }
+
+	bool AddRoute(const char* pluginName, const char* folderName)
+	{
+		if (!pluginName || !folderName || folderName[0] == '\0')
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] AddRoute: invalid arguments");
+			return false;
+		}
+
+		// Resolve the plugin's directory from the modloader DLL path, not the exe path.
+		// The modloader DLL lives at:  <game>\Binaries\Win64\version.dll  (or similar)
+		// Plugin DLLs live at:         <game>\Binaries\Win64\Plugins\<pluginName>\<pluginName>.dll
+		// Static files live at:    <game>\Binaries\Win64\Plugins\<pluginName>\<folderName>\
+		// We find the modloader DLL path and derive the Plugins directory from its parent.
+		wchar_t dllPath[MAX_PATH]{};
+		HMODULE hSelf = nullptr;
+		GetModuleHandleExW(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCWSTR>(&AddRoute),
+			&hSelf);
+		GetModuleFileNameW(hSelf, dllPath, MAX_PATH);
+		// Strip filename to get directory containing the modloader DLL
+		if (wchar_t* s = wcsrchr(dllPath, L'\\')) *s = L'\0';
+
+		wchar_t pluginNameW[256]{}, folderNameW[256]{};
+		MultiByteToWideChar(CP_UTF8, 0, pluginName, -1, pluginNameW, 256);
+		MultiByteToWideChar(CP_UTF8, 0, folderName, -1, folderNameW, 256);
+
+		wchar_t fsRoot[MAX_PATH]{};
+		swprintf_s(fsRoot, L"%s\\Plugins\\%s\\%s", dllPath, pluginNameW, folderNameW);
+
+		auto toLower = [](std::string s) {
+			std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
+			return s;
+			};
+		std::string prefix = "/" + toLower(pluginName) + "/" + toLower(folderName) + "/";
+
+		std::lock_guard lock(g_routesMutex);
+		for (const auto& r : g_routes)
+			if (r.urlPrefix == prefix)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] AddRoute: already registered: %S", prefix.c_str());
+				return false;
+			}
+
+		RouteEntry entry;
+		entry.pluginName = pluginName;
+		entry.folderName = folderName;
+		entry.fsRoot = fsRoot;
+		entry.urlPrefix = prefix;
+		g_routes.push_back(std::move(entry));
+
+		ModLoaderLogger::LogInfo(L"[HttpServer] Route registered: %S  ->  %s", prefix.c_str(), fsRoot);
+		return true;
+	}
+
+	void RemoveRoute(const char* pluginName, const char* folderName)
+	{
+		if (!pluginName || !folderName) return;
+		auto toLower = [](std::string s) {
+			std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
+			return s;
+			};
+		std::string prefix = "/" + toLower(pluginName) + "/" + toLower(folderName) + "/";
+		std::lock_guard lock(g_routesMutex);
+		auto it = std::remove_if(g_routes.begin(), g_routes.end(),
+			[&](const RouteEntry& r) { return r.urlPrefix == prefix; });
+		if (it != g_routes.end())
+		{
+			g_routes.erase(it, g_routes.end());
+			ModLoaderLogger::LogInfo(L"[HttpServer] Route unregistered: %S", prefix.c_str());
+		}
+	}
+
+	void RegisterRawRequestFilter(PluginHttpRequestFilterCallback callback)
+	{
+		if (!callback) { ModLoaderLogger::LogWarn(L"[HttpServer] RegisterRawRequestFilter: null callback"); return; }
+		std::lock_guard lock(g_filtersMutex);
+		g_filters.push_back(callback);
+		ModLoaderLogger::LogDebug(L"[HttpServer] Raw-request filter registered (%zu total)", g_filters.size());
+	}
+
+	void UnregisterRawRequestFilter(PluginHttpRequestFilterCallback callback)
+	{
+		if (!callback) return;
+		std::lock_guard lock(g_filtersMutex);
+		auto it = std::find(g_filters.begin(), g_filters.end(), callback);
+		if (it != g_filters.end())
+		{
+			g_filters.erase(it);
+			ModLoaderLogger::LogDebug(L"[HttpServer] Raw-request filter unregistered (%zu remaining)", g_filters.size());
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Raw-response route registration
+	// ---------------------------------------------------------------------------
+	bool AddRawRoute(const char* pluginName, const char* urlPrefix, PluginHttpRouteCallback callback)
+	{
+		if (!pluginName || !urlPrefix || urlPrefix[0] == '\0' || !callback)
+		{
+			ModLoaderLogger::LogWarn(L"[HttpServer] AddRawRoute: invalid arguments");
+			return false;
+		}
+
+		auto toLower = [](std::string s) {
+			std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
+			return s;
+			};
+		// URL prefix: /<pluginName>/<urlPrefix>/  (no /plugins/ prefix)
+		std::string prefix = "/" + toLower(pluginName) + "/" + toLower(urlPrefix) + "/";
+
+		std::lock_guard lock(g_rawRoutesMutex);
+		for (const auto& r : g_rawRoutes)
+			if (r.urlPrefix == prefix)
+			{
+				ModLoaderLogger::LogWarn(L"[HttpServer] AddRawRoute: already registered: %S", prefix.c_str());
+				return false;
+			}
+
+		RawRouteEntry entry;
+		entry.pluginName = pluginName;
+		entry.urlPrefix = prefix;
+		entry.callback = callback;
+		g_rawRoutes.push_back(std::move(entry));
+
+		ModLoaderLogger::LogInfo(L"[HttpServer] Raw route registered: %S", prefix.c_str());
+		return true;
+	}
+
+	void RemoveRawRoute(const char* pluginName, const char* urlPrefix)
+	{
+		if (!pluginName || !urlPrefix) return;
+
+		auto toLower = [](std::string s) {
+			std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
+			return s;
+			};
+		std::string prefix = "/" + toLower(pluginName) + "/" + toLower(urlPrefix) + "/";
+
+		std::lock_guard lock(g_rawRoutesMutex);
+		auto it = std::remove_if(g_rawRoutes.begin(), g_rawRoutes.end(),
+			[&](const RawRouteEntry& r) { return r.urlPrefix == prefix; });
+		if (it != g_rawRoutes.end())
+		{
+			g_rawRoutes.erase(it, g_rawRoutes.end());
+			ModLoaderLogger::LogInfo(L"[HttpServer] Raw route unregistered: %S", prefix.c_str());
+		}
+	}
+
+} // namespace Hooks::HttpServer

--- a/Version_Mod_Loader/hooks/http/http_server_hook.h
+++ b/Version_Mod_Loader/hooks/http/http_server_hook.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "plugins/plugin_interface.h"
+#include <cstdint>
+#include <cstddef>
+
+// ---------------------------------------------------------------------------
+// Hooks::HttpServer
+//
+// Modloader-owned hook on FHttpConnection::ProcessRequest.
+//
+// URL scheme (always case-insensitive):
+//   /<pluginName>/<routeName>/...
+//
+// Detour pipeline (in order):
+//   1. Raw-request filters  — RegisterRawRequestFilter / UnregisterRawRequestFilter
+//     First Deny sends 403 and stops all further processing.
+//   2. Raw-response routes  — AddRawRoute / RemoveRawRoute
+// Plugin-owned handler; plugin writes status, content-type, and body.
+//   3. Static-file routes   — AddRoute / RemoveRoute
+//Files served from <exe_dir>\Plugins\<pluginName>\<folderName>\.
+//   4. Pass-through         — the original engine handler is called.
+//
+// This subsystem is only installed on server builds.
+// hooks->HttpServer is nullptr on client and generic builds.
+// ---------------------------------------------------------------------------
+
+namespace Hooks::HttpServer
+{
+	// -----------------------------------------------------------------------
+	// Lifecycle — called by the modloader (dllmain / hooks_interface)
+	// -----------------------------------------------------------------------
+
+	bool Install();
+	void Remove();
+	bool IsInstalled();
+
+	// -----------------------------------------------------------------------
+	// Static-file routes
+	// URL matched: /<pluginName>/<folderName>/...  (case-insensitive)
+	// Files served from: <exe_dir>\Plugins\<pluginName>\<folderName>\
+	// -----------------------------------------------------------------------
+
+	bool AddRoute(const char* pluginName, const char* folderName);
+	void RemoveRoute(const char* pluginName, const char* folderName);
+
+	// -----------------------------------------------------------------------
+	// Raw-request filters
+	// -----------------------------------------------------------------------
+
+	void RegisterRawRequestFilter(PluginHttpRequestFilterCallback callback);
+	void UnregisterRawRequestFilter(PluginHttpRequestFilterCallback callback);
+
+	// -----------------------------------------------------------------------
+	// Raw-response routes
+	// URL matched: /<pluginName>/<urlPrefix>/...  (case-insensitive)
+	// -----------------------------------------------------------------------
+
+	bool AddRawRoute(const char* pluginName, const char* urlPrefix, PluginHttpRouteCallback callback);
+	void RemoveRawRoute(const char* pluginName, const char* urlPrefix);
+
+} // namespace Hooks::HttpServer

--- a/Version_Mod_Loader/plugins/plugin_interface.h
+++ b/Version_Mod_Loader/plugins/plugin_interface.h
@@ -3,70 +3,44 @@
 #include <windows.h>
 #include <cstdint>
 
-// v19: Introduced IPluginSelf — a single struct bundling name, version, logger, config, scanner,
-//      and hooks. PluginInit now receives IPluginSelf* instead of four separate pointers.
-//      Removed const char* pluginName from IPluginLogger, IPluginConfig, and IPluginNetworkChannel;
-//      replaced with const IPluginSelf* so the loader can identify the calling plugin without
-//      plugins having to duplicate their own name string in every call.
-//      MIN bumped to 19 (ABI break — all plugins must be recompiled against this header).
-// v20: Added OnBeforeWorldEndPlay / OnAfterWorldEndPlay to IPluginWorldEvents.
-//      MIN remains 19 — loader accepts v19 plugins (they won't use the new callbacks).
-// v21: Added IPluginNativePointers to IPluginHooks (hooks->NativePointers).
-//    Exposes the trampoline (original) function address for every managed hook so
-//      plugins can call the real game function directly without installing their own hook.
-//      MIN remains 19 — v19/v20 plugins simply ignore the new field.
-#define PLUGIN_INTERFACE_VERSION_MIN 19  // oldest plugin ABI still accepted by this loader
-#define PLUGIN_INTERFACE_VERSION_MAX 21  // current interface version (this header)
-#define PLUGIN_INTERFACE_VERSION PLUGIN_INTERFACE_VERSION_MAX  // alias used by plugins in PluginInfo
+// v19: Introduced IPluginSelf.  MIN bumped to 19.
+// v20: Added OnBeforeWorldEndPlay / OnAfterWorldEndPlay.  MIN remains 19.
+// v21: Added IPluginNativePointers.  MIN remains 19.
+// v22: Added IPluginHttpServer (hooks->HttpServer).
+//   Static file route registration (AddRoute/RemoveRoute), raw-request
+//      filter hook (RegisterOnRawRequest/UnregisterOnRawRequest), and
+//  raw-response route registration (AddRawRoute/RemoveRawRoute).
+//      URL scheme: /<pluginName>/<routeName>/...  (case-insensitive).
+//      Static files are served from <exe_dir>\Plugins\<pluginName>\<folderName>\.
+//      Raw-response routes let plugins handle arbitrary URL prefixes and write
+//      any response body + content-type directly (e.g. JSON API endpoints).
+//   Server builds only; nullptr on client/generic builds.
+//      MIN remains 19.
+#define PLUGIN_INTERFACE_VERSION_MIN 19
+#define PLUGIN_INTERFACE_VERSION_MAX 22
+#define PLUGIN_INTERFACE_VERSION PLUGIN_INTERFACE_VERSION_MAX
 
-// Log levels
-enum class PluginLogLevel
-{
-	Trace = 0,
-	Debug = 1,
-	Info = 2,
-	Warn = 3,
-	Error = 4
-};
+enum class PluginLogLevel { Trace = 0, Debug = 1, Info = 2, Warn = 3, Error = 4 };
+enum class ConfigValueType { String, Integer, Float, Boolean };
 
-// Config value types
-enum class ConfigValueType
-{
-	String,
-	Integer,
-	Float,
-	Boolean
-};
-
-// Config entry definition for auto-generation
 struct ConfigEntry
 {
-	const char* section;      // INI section name (e.g., "General", "Advanced")
-	const char* key;          // INI key name
-	ConfigValueType type;     // Value type
-	const char* defaultValue; // Default value as string (converted based on type)
-	const char* description;  // Optional description/comment
-	float rangeMin;           // Slider min -- ignored when rangeMax <= rangeMin
-	float rangeMax;           // Slider max -- when rangeMax > rangeMin a slider is shown
+	const char* section;
+	const char* key;
+	ConfigValueType type;
+	const char* defaultValue;
+	const char* description;
+	float rangeMin;
+	float rangeMax;
 };
 
-// Config schema - defines all config entries for a plugin
-struct ConfigSchema
-{
-	const ConfigEntry* entries; // Array of config entries
-	int entryCount;          // Number of entries in array
-};
+struct ConfigSchema { const ConfigEntry* entries; int entryCount; };
 
-// Forward declaration — IPluginSelf is defined after IPluginHooks (all sub-interfaces must be complete first).
-struct IPluginSelf;
+struct IPluginSelf; // forward — defined after all sub-interfaces
 
-// Universal logger interface provided by mod loader
 struct IPluginLogger
 {
-	// Log a message with the specified level
 	void (*Log)(PluginLogLevel level, const IPluginSelf* self, const char* message);
-
-	// Convenience methods
 	void (*Trace)(const IPluginSelf* self, const char* format, ...);
 	void (*Debug)(const IPluginSelf* self, const char* format, ...);
 	void (*Info) (const IPluginSelf* self, const char* format, ...);
@@ -74,117 +48,40 @@ struct IPluginLogger
 	void (*Error)(const IPluginSelf* self, const char* format, ...);
 };
 
-// Config manager interface provided by mod loader
 struct IPluginConfig
 {
-	// Read string value from plugin's config file
-	bool (*ReadString)(const IPluginSelf* self, const char* section, const char* key, char* outValue, int maxLen, const char* defaultValue);
-
-	// Write string value to plugin's config file
-	bool (*WriteString)(const IPluginSelf* self, const char* section, const char* key, const char* value);
-
-	// Read integer value from plugin's config file
-	int (*ReadInt)(const IPluginSelf* self, const char* section, const char* key, int defaultValue);
-
-	// Write integer value to plugin's config file
-	bool (*WriteInt)(const IPluginSelf* self, const char* section, const char* key, int value);
-
-	// Read float value from plugin's config file
+	bool  (*ReadString)(const IPluginSelf* self, const char* section, const char* key, char* outValue, int maxLen, const char* defaultValue);
+	bool  (*WriteString)(const IPluginSelf* self, const char* section, const char* key, const char* value);
+	int   (*ReadInt)(const IPluginSelf* self, const char* section, const char* key, int defaultValue);
+	bool  (*WriteInt)(const IPluginSelf* self, const char* section, const char* key, int value);
 	float (*ReadFloat)(const IPluginSelf* self, const char* section, const char* key, float defaultValue);
-
-	// Write float value to plugin's config file
-	bool (*WriteFloat)(const IPluginSelf* self, const char* section, const char* key, float value);
-
-	// Read boolean value from plugin's config file
-	bool (*ReadBool)(const IPluginSelf* self, const char* section, const char* key, bool defaultValue);
-
-	// Write boolean value to plugin's config file
-	bool (*WriteBool)(const IPluginSelf* self, const char* section, const char* key, bool value);
-
-	// Initialize plugin config from schema
-	// Creates config file with defaults if it doesn't exist
-	// Returns true if config was loaded/created successfully
-	bool (*InitializeFromSchema)(const IPluginSelf* self, const ConfigSchema* schema);
-
-	// Validate and repair config file based on schema
-	// Adds missing entries with defaults, preserves existing values
-	void (*ValidateConfig)(const IPluginSelf* self, const ConfigSchema* schema);
+	bool  (*WriteFloat)(const IPluginSelf* self, const char* section, const char* key, float value);
+	bool  (*ReadBool)(const IPluginSelf* self, const char* section, const char* key, bool defaultValue);
+	bool  (*WriteBool)(const IPluginSelf* self, const char* section, const char* key, bool value);
+	bool  (*InitializeFromSchema)(const IPluginSelf* self, const ConfigSchema* schema);
+	void  (*ValidateConfig)(const IPluginSelf* self, const ConfigSchema* schema);
 };
 
-// A single cross-reference result returned by the xref scanner.
-// isRelative: true  = relative near CALL (E8) or JMP (E9) instruction
-//             false = absolute 8-byte function pointer (vtable, data, etc.)
-struct PluginXRef
-{
-	uintptr_t address;    // Address of the referencing instruction / pointer slot
-	bool      isRelative; // true = relative CALL/JMP  |  false = absolute pointer
-};
+struct PluginXRef { uintptr_t address; bool isRelative; };
 
-// Pattern scanner interface provided by mod loader
-// Use IDA-style patterns: "48 89 5C 24 ?? 57 48 83 EC 20" where ?? is wildcard
 struct IPluginScanner
 {
-	// Find the first occurrence of a pattern in the main executable module
-	// Returns the absolute address of the match, or 0 if not found
-	uintptr_t(*FindPatternInMainModule)(const char* pattern);
-
-	// Find the first occurrence of a pattern in a specific module
-	// Returns the absolute address of the match, or 0 if not found
-	uintptr_t(*FindPatternInModule)(HMODULE module, const char* pattern);
-
-	// Find all occurrences of a pattern in the main executable module.
-	// Writes up to maxResults addresses into outAddresses and returns the total match count.
-	// Pass outAddresses=nullptr / maxResults=0 to query the count without writing.
-	// Safe across DLL boundaries - no heap ownership transfer.
+	uintptr_t (*FindPatternInMainModule)(const char* pattern);
+	uintptr_t (*FindPatternInModule)(HMODULE module, const char* pattern);
 	int (*FindAllPatternsInMainModule)(const char* pattern, uintptr_t* outAddresses, int maxResults);
-
-	// Find all occurrences of a pattern in a specific module.
-	// Writes up to maxResults addresses into outAddresses and returns the total match count.
-	// Pass outAddresses=nullptr / maxResults=0 to query the count without writing.
-	// Safe across DLL boundaries - no heap ownership transfer.
 	int (*FindAllPatternsInModule)(HMODULE module, const char* pattern, uintptr_t* outAddresses, int maxResults);
-
-	// Find a unique pattern from a list of candidates
-	// Returns the address if exactly one pattern matches exactly once
-	// Returns 0 if no patterns match uniquely
-	// outPatternIndex (if provided) is set to the index of the matching pattern
-	uintptr_t(*FindUniquePattern)(const char** patterns, int patternCount, int* outPatternIndex);
-
-	// XRef scanning - find all locations that reference a given address.
-	//
-	// Two reference types are detected:
-	//   - Absolute 8-byte pointer: any 8-byte-aligned slot whose value equals
-	//     targetAddress exactly (vtables, function-pointer arrays, global data).
-	//   - Relative near CALL (E8) / JMP (E9): instruction whose computed target
-	//     equals targetAddress.
-	//
-	// All three variants use the caller-buffer pattern (safe across DLL boundaries):
-	//   pass outXRefs=nullptr / maxResults=0 to query the count only.
-	//
-	// FindXrefsToAddress          - scan an arbitrary memory range [start, start+size)
-	// FindXrefsToAddressInModule  - scan an entire PE module
-	// FindXrefsToAddressInMainModule - convenience: scans the main .exe module
-	int (*FindXrefsToAddress)(uintptr_t targetAddress, uintptr_t start, size_t size,
-		PluginXRef* outXRefs, int maxResults);
-	int (*FindXrefsToAddressInModule)(uintptr_t targetAddress, HMODULE module,
-		PluginXRef* outXRefs, int maxResults);
-	int (*FindXrefsToAddressInMainModule)(uintptr_t targetAddress,
-		PluginXRef* outXRefs, int maxResults);
+	uintptr_t (*FindUniquePattern)(const char** patterns, int patternCount, int* outPatternIndex);
+	int (*FindXrefsToAddress)(uintptr_t targetAddress, uintptr_t start, size_t size, PluginXRef* outXRefs, int maxResults);
+	int (*FindXrefsToAddressInModule)(uintptr_t targetAddress, HMODULE module, PluginXRef* outXRefs, int maxResults);
+	int (*FindXrefsToAddressInMainModule)(uintptr_t targetAddress, PluginXRef* outXRefs, int maxResults);
 };
 
-// Opaque hook handle - plugins don't need to know the internals
 typedef void* HookHandle;
-
-// Forward declare SDK::UWorld for callback
 namespace SDK { class UWorld; }
 
-// ============================================================
-// Event callback typedefs (v14)
-// Named equivalents of the anonymous inline types used in the flat IPluginHooks
-// fields. Used by the typed sub-interface structs (IPluginEngineEvents, etc.)
-// and may also be used by plugin authors for cleaner callback declarations.
-// ============================================================
-
+// ---------------------------------------------------------------------------
+// Callback typedefs (v14+)
+// ---------------------------------------------------------------------------
 typedef void (*PluginEngineInitCallback)();
 typedef void (*PluginEngineShutdownCallback)();
 typedef void (*PluginEngineTickCallback)(float deltaSeconds);
@@ -196,62 +93,28 @@ typedef void (*PluginActorBeginPlayCallback)(void* actor);
 typedef void (*PluginPlayerJoinedCallback)(void* playerController);
 typedef void (*PluginPlayerLeftCallback)(void* exitingController);
 typedef void (*PluginWorldEndPlayCallback)(SDK::UWorld* world, const char* worldName);
-// v16 (client only) — fired after AHUD::PostRender; hud is AHUD* cast to void*
 typedef void (*PluginHUDPostRenderCallback)(void* hud);
-// v17 -- fired on the client when a server packet arrives for this plugin+typeTag.
-// pluginName : the name the server-side plugin passed to SendPacketToClient/SendPacketToAllClients
-// typeTag    : identifies the packet type (use typeid(T).name() via plugin_network_helpers.h)
-// data       : decoded payload bytes -- exactly 'size' bytes; pointer is valid only during this call
-// size       : byte count of the payload; always > 0
-typedef void (*PluginNetworkMessageCallback)(const char* pluginName, const char* typeTag,
-	const uint8_t* data, size_t size);
-
-// v18 -- fired on the server when a client packet arrives for this plugin+typeTag.
-// senderPlayerController : the APlayerController* of the sending client cast to void*
-// pluginName / typeTag / data / size : same semantics as PluginNetworkMessageCallback
-typedef void (*PluginNetworkServerMessageCallback)(void* senderPlayerController,
-	const char* pluginName, const char* typeTag,
-	const uint8_t* data, size_t size);
-
-// v18 -- callback type for PostToGameThread.
-// context : the void* passed to PostToGameThread; cast to your own struct inside the callback.
+typedef void (*PluginNetworkMessageCallback)(const char* pluginName, const char* typeTag, const uint8_t* data, size_t size);
+typedef void (*PluginNetworkServerMessageCallback)(void* senderPlayerController, const char* pluginName, const char* typeTag, const uint8_t* data, size_t size);
 typedef void (*PluginGameThreadCallback)(void* context);
 
-// ============================================================
-// Spawner hook callback typedefs (v14)
-// Used with IPluginSpawnerHooks accessible via hooks->Spawner
-// ============================================================
-
-// AAbstractMassEnemySpawner::ActivateSpawner — Before: return true to cancel
 typedef bool (*PluginBeforeActivateSpawnerCallback)(void* spawner, bool bDisableAggroLock);
-// AAbstractMassEnemySpawner::ActivateSpawner — After: fires only if not cancelled
 typedef void (*PluginAfterActivateSpawnerCallback)(void* spawner, bool bDisableAggroLock);
-
-// AAbstractMassEnemySpawner::DeactivateSpawner — Before: return true to cancel
 typedef bool (*PluginBeforeDeactivateSpawnerCallback)(void* spawner, bool bPermanently);
-// AAbstractMassEnemySpawner::DeactivateSpawner — After: fires only if not cancelled
 typedef void (*PluginAfterDeactivateSpawnerCallback)(void* spawner, bool bPermanently);
-
-// AMassSpawner::DoSpawning — Before: return true to cancel the batch spawn
 typedef bool (*PluginBeforeDoSpawningCallback)(void* spawner);
-// AMassSpawner::DoSpawning — After: fires only if not cancelled
 typedef void (*PluginAfterDoSpawningCallback)(void* spawner);
 
-// ============================================================
-// IPluginHookUtils — low-level hook install/remove/query (v14)
-// Access via: hooks->Hooks->Install(...)
-// ============================================================
+// ---------------------------------------------------------------------------
+// Sub-interface structs (v14)
+// ---------------------------------------------------------------------------
 struct IPluginHookUtils
 {
-	HookHandle(*Install)(uintptr_t targetAddress, void* detourFunction, void** originalFunction);
+	HookHandle (*Install)(uintptr_t targetAddress, void* detourFunction, void** originalFunction);
 	void       (*Remove)(HookHandle handle);
 	bool       (*IsInstalled)(HookHandle handle);
 };
 
-// ============================================================
-// IPluginMemoryUtils — memory patch/nop/read/alloc utilities (v14)
-// Access via: hooks->Memory->Patch(...)
-// ============================================================
 struct IPluginMemoryUtils
 {
 	bool  (*Patch)(uintptr_t address, const uint8_t* data, size_t size);
@@ -262,32 +125,18 @@ struct IPluginMemoryUtils
 	bool  (*IsAllocatorAvailable)();
 };
 
-// ============================================================
-// IPluginEngineEvents — engine lifecycle event subscriptions (v14)
-// Access via: hooks->Engine->RegisterOnInit(...)
-// ============================================================
 struct IPluginEngineEvents
 {
-	void (*RegisterOnInit)(PluginEngineInitCallback);
-	void (*UnregisterOnInit)(PluginEngineInitCallback);
-	void (*RegisterOnShutdown)(PluginEngineShutdownCallback);
-	void (*UnregisterOnShutdown)(PluginEngineShutdownCallback);
-	void (*RegisterOnTick)(PluginEngineTickCallback);
-	void (*UnregisterOnTick)(PluginEngineTickCallback);
-	// v16 -- resolved address of CoreUObject::StaticLoadObject, or 0 if not found.
-	// Available on all build types.
-	uintptr_t(*GetStaticLoadObjectAddress)();
-	// v18 -- post a fire-and-forget callback onto the game thread.
-	// fn is called from the game thread during the next engine tick.
-	// context is passed unchanged to fn; pass nullptr if you have no state.
-	// Thread-safe; may be called from any thread (RCON handlers, network callbacks, etc.).
-	void (*PostToGameThread)(PluginGameThreadCallback fn, void* context);
+	void      (*RegisterOnInit)(PluginEngineInitCallback);
+	void      (*UnregisterOnInit)(PluginEngineInitCallback);
+	void      (*RegisterOnShutdown)(PluginEngineShutdownCallback);
+	void      (*UnregisterOnShutdown)(PluginEngineShutdownCallback);
+	void      (*RegisterOnTick)(PluginEngineTickCallback);
+	void    (*UnregisterOnTick)(PluginEngineTickCallback);
+	uintptr_t (*GetStaticLoadObjectAddress)();           // v16
+	void      (*PostToGameThread)(PluginGameThreadCallback fn, void* context); // v18
 };
 
-// ============================================================
-// IPluginWorldEvents — world / level event subscriptions (v14)
-// Access via: hooks->World->RegisterOnWorldBeginPlay(...)
-// ============================================================
 struct IPluginWorldEvents
 {
 	void (*RegisterOnWorldBeginPlay)(PluginWorldBeginPlayCallback);
@@ -298,18 +147,12 @@ struct IPluginWorldEvents
 	void (*UnregisterOnSaveLoaded)(PluginSaveLoadedCallback);
 	void (*RegisterOnExperienceLoadComplete)(PluginExperienceLoadCompleteCallback);
 	void (*UnregisterOnExperienceLoadComplete)(PluginExperienceLoadCompleteCallback);
-	// Fired before UWorld::EndPlay runs (world still valid). world/worldName valid for the call duration.
-	void (*RegisterOnBeforeWorldEndPlay)(PluginWorldEndPlayCallback);
-	void (*UnregisterOnBeforeWorldEndPlay)(PluginWorldEndPlayCallback);
-	// Fired after UWorld::EndPlay runs. world pointer may be partially torn down; use worldName only.
-	void (*RegisterOnAfterWorldEndPlay)(PluginWorldEndPlayCallback);
-	void (*UnregisterOnAfterWorldEndPlay)(PluginWorldEndPlayCallback);
+	void (*RegisterOnBeforeWorldEndPlay)(PluginWorldEndPlayCallback);   // v20
+	void (*UnregisterOnBeforeWorldEndPlay)(PluginWorldEndPlayCallback); // v20
+	void (*RegisterOnAfterWorldEndPlay)(PluginWorldEndPlayCallback);    // v20
+	void (*UnregisterOnAfterWorldEndPlay)(PluginWorldEndPlayCallback);  // v20
 };
 
-// ============================================================
-// IPluginPlayerEvents — player join/leave event subscriptions (v14)
-// Access via: hooks->Players->RegisterOnPlayerJoined(...)
-// ============================================================
 struct IPluginPlayerEvents
 {
 	void (*RegisterOnPlayerJoined)(PluginPlayerJoinedCallback);
@@ -318,468 +161,330 @@ struct IPluginPlayerEvents
 	void (*UnregisterOnPlayerLeft)(PluginPlayerLeftCallback);
 };
 
-// ============================================================
-// IPluginActorEvents — actor lifecycle event subscriptions (v14)
-// Access via: hooks->Actors->RegisterOnActorBeginPlay(...)
-// ============================================================
 struct IPluginActorEvents
 {
 	void (*RegisterOnActorBeginPlay)(PluginActorBeginPlayCallback);
 	void (*UnregisterOnActorBeginPlay)(PluginActorBeginPlayCallback);
 };
 
-// ============================================================
-// IPluginSpawnerHooks — enemy spawner Before/After hook group (v14)
-// Access via: hooks->Spawner->RegisterOnBeforeActivate(...)
-// Before callbacks run in registration order; any returning true cancels the
-// operation and suppresses the original call and all After callbacks.
-// ============================================================
 struct IPluginSpawnerHooks
 {
-	// -----------------------------------------------------------------------
-	// AAbstractMassEnemySpawner::ActivateSpawner(bool bDisableAggroLock) (v14)
-	// Before: fires before the spawner activates. Return true to cancel.
-	// After:  fires after the spawner has activated (only if not cancelled).
-	// Spawner pointer is AAbstractMassEnemySpawner* passed as void*.
-	// -----------------------------------------------------------------------
 	void (*RegisterOnBeforeActivate)(PluginBeforeActivateSpawnerCallback callback);
 	void (*UnregisterOnBeforeActivate)(PluginBeforeActivateSpawnerCallback callback);
 	void (*RegisterOnAfterActivate)(PluginAfterActivateSpawnerCallback callback);
 	void (*UnregisterOnAfterActivate)(PluginAfterActivateSpawnerCallback callback);
-
-	// -----------------------------------------------------------------------
-	// AAbstractMassEnemySpawner::DeactivateSpawner(bool bPermanently) (v14)
-	// Before: fires before the spawner deactivates. Return true to cancel.
-	// After:  fires after the spawner has deactivated (only if not cancelled).
-	// Spawner pointer is AAbstractMassEnemySpawner* passed as void*.
-	// -----------------------------------------------------------------------
 	void (*RegisterOnBeforeDeactivate)(PluginBeforeDeactivateSpawnerCallback callback);
 	void (*UnregisterOnBeforeDeactivate)(PluginBeforeDeactivateSpawnerCallback callback);
 	void (*RegisterOnAfterDeactivate)(PluginAfterDeactivateSpawnerCallback callback);
 	void (*UnregisterOnAfterDeactivate)(PluginAfterDeactivateSpawnerCallback callback);
-
-	// -----------------------------------------------------------------------
-	// AMassSpawner::DoSpawning() (v14)
-	// Before: fires before the Mass Entity batch is spawned. Return true to cancel.
-	// After:  fires after the batch has been spawned (only if not cancelled).
-	// Spawner pointer is AMassSpawner* passed as void*.
-	// -----------------------------------------------------------------------
 	void (*RegisterOnBeforeDoSpawning)(PluginBeforeDoSpawningCallback callback);
 	void (*UnregisterOnBeforeDoSpawning)(PluginBeforeDoSpawningCallback callback);
 	void (*RegisterOnAfterDoSpawning)(PluginAfterDoSpawningCallback callback);
 	void (*UnregisterOnAfterDoSpawning)(PluginAfterDoSpawningCallback callback);
 };
 
-// ============================================================
-// EModKey — enumeration of keys that can be bound by plugins (v15)
-// Maps directly to Unreal Engine EKeys names and Win32 VK codes.
-// Use with IPluginInputEvents::RegisterKeybind or RegisterKeybindByName.
-// ============================================================
+// ---------------------------------------------------------------------------
+// Input (v15, client only)
+// ---------------------------------------------------------------------------
 enum class EModKey : uint32_t
 {
-	// Function keys
 	F1 = 0, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
-
-	// Letters
 	A, B, C, D, E, F, G, H, I, J, K, L, M,
 	N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
-
-	// Digit row
 	Zero, One, Two, Three, Four, Five, Six, Seven, Eight, Nine,
-
-	// Control keys
 	Escape, Tab, CapsLock, SpaceBar, Enter, BackSpace, Delete, Insert,
-
-	// Modifier keys
 	LeftShift, RightShift, LeftControl, RightControl, LeftAlt, RightAlt,
-
-	// Navigation keys
 	Up, Down, Left, Right, Home, End, PageUp, PageDown,
-
-	// Punctuation / OEM keys
 	Tilde, Hyphen, Equals, LeftBracket, RightBracket, Backslash,
 	Semicolon, Apostrophe, Comma, Period, Slash,
-
-	// Numpad digits
 	NumPadZero, NumPadOne, NumPadTwo, NumPadThree, NumPadFour,
 	NumPadFive, NumPadSix, NumPadSeven, NumPadEight, NumPadNine,
-
-	// Numpad operators
 	Add, Subtract, Multiply, Divide, Decimal,
-
-	// Mouse buttons
 	LeftMouseButton, RightMouseButton, MiddleMouseButton,
 	ThumbMouseButton, ThumbMouseButton2,
-
-	Unknown  // sentinel / error value
+	Unknown
 };
 
-// ============================================================
-// EModKeyEvent — key state transitions reported to keybind callbacks (v15)
-// ============================================================
-enum class EModKeyEvent : uint32_t
-{
-	Pressed = 0,   // fired once when the key goes from up to down
-	Released = 1    // fired once when the key goes from down to up
-};
+enum class EModKeyEvent : uint32_t { Pressed = 0, Released = 1 };
 
-// ============================================================
-// PluginKeybindCallback — signature for keybind event callbacks (v15)
-// key   : the key that changed state
-// event : Pressed or Released
-// ============================================================
 typedef void (*PluginKeybindCallback)(EModKey key, EModKeyEvent event);
 
-// ============================================================
-// IPluginInputEvents — keybind event subscriptions (v15, client only)
-// Access via: hooks->Input->RegisterKeybind(...)
-// hooks->Input is nullptr on server and generic builds.
-// Both the enum API and the string API resolve to the same underlying handler.
-// UE key name strings are case-insensitive ("F1", "LeftShift", "Tilde", etc.)
-// ============================================================
 struct IPluginInputEvents
 {
-	// Register a callback for a specific key+event (by enum)
 	void (*RegisterKeybind)(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
-	// Unregister a previously registered callback (by enum)
 	void (*UnregisterKeybind)(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
-
-	// Register a callback for a specific key+event (by UE key name string)
-	// keyName is matched case-insensitively, e.g. "F1", "LeftShift", "Tilde"
 	void (*RegisterKeybindByName)(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
-	// Unregister a previously registered callback (by UE key name string)
 	void (*UnregisterKeybindByName)(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
 };
 
-// ============================================================
-// IModLoaderImGui — ImGui function table exposed to plugins (v15)
-// The modloader owns Dear ImGui; plugins must NOT call ImGui:: directly.
-// Call through this table inside a PluginImGuiRenderCallback.
-// All text parameters are plain C strings — format with snprintf before calling.
-// ============================================================
+// ---------------------------------------------------------------------------
+// UI (v15–v16, client only)
+// ---------------------------------------------------------------------------
 struct IModLoaderImGui
 {
-	// --- Text ---
 	void (*Text)(const char* text);
-	void (*TextColored)(float r, float g, float b, float a, const char* text);
+	void (*TextColored)(float r, float g, float a, const char* text);
 	void (*TextDisabled)(const char* text);
 	void (*TextWrapped)(const char* text);
 	void (*LabelText)(const char* label, const char* text);
 	void (*SeparatorText)(const char* label);
-
-	// --- Inputs (return true when value changed) ---
 	bool (*InputText)(const char* label, char* buf, size_t buf_size);
 	bool (*InputInt)(const char* label, int* v, int step, int step_fast);
 	bool (*InputFloat)(const char* label, float* v, float step, float step_fast, const char* format);
 	bool (*Checkbox)(const char* label, bool* v);
 	bool (*SliderFloat)(const char* label, float* v, float v_min, float v_max, const char* format);
 	bool (*SliderInt)(const char* label, int* v, int v_min, int v_max, const char* format);
-
-	// --- Buttons ---
 	bool (*Button)(const char* label);
 	bool (*SmallButton)(const char* label);
-
-	// --- Layout ---
 	void (*SameLine)(float offset_from_start_x, float spacing);
 	void (*NewLine)();
 	void (*Separator)();
 	void (*Spacing)();
 	void (*Indent)(float indent_w);
 	void (*Unindent)(float indent_w);
-
-	// --- ID stack ---
 	void (*PushIDStr)(const char* str_id);
 	void (*PushIDInt)(int int_id);
 	void (*PopID)();
-
-	// --- Combo / Selectable ---
 	bool (*BeginCombo)(const char* label, const char* preview_value);
 	bool (*Selectable)(const char* label, bool selected);
 	void (*EndCombo)();
-
-	// --- Tree / Collapsible ---
 	bool (*CollapsingHeader)(const char* label);
 	bool (*TreeNodeStr)(const char* label);
 	void (*TreePop)();
-
-	// --- Color ---
 	bool (*ColorEdit3)(const char* label, float col[3]);
 	bool (*ColorEdit4)(const char* label, float col[4]);
-
-	// --- Misc ---
 	void (*SetTooltip)(const char* text);
 	bool (*IsItemHovered)();
 	void (*SetNextItemWidth)(float item_width);
 };
 
-// Render callback for a plugin-registered custom panel.
-// Called by the modloader each frame while the panel window is open.
-// imgui: the function table above — use it for all ImGui calls.
 typedef void (*PluginImGuiRenderCallback)(IModLoaderImGui* imgui);
 
-// Descriptor passed to IPluginUIEvents::RegisterPanel.
 struct PluginPanelDesc
 {
-	const char* buttonLabel;        // button label shown in ModLoader Config tab
-	const char* windowTitle;        // ImGui window title (must be globally unique)
+	const char* buttonLabel;
+	const char* windowTitle;
 	PluginImGuiRenderCallback renderFn;
 };
 
-// Opaque handle returned by IPluginUIEvents::SetPanelOpen.
-// Pass it to SetPanelClose to close the same panel.
-// Null means the panel was not found or the UI backend is disabled.
 typedef void* PanelHandle;
-
-// Opaque handle returned by IPluginUIEvents::RegisterWidget.
-// Pass it to UnregisterWidget during PluginShutdown.
-// Null means registration failed or the UI backend is disabled.
 typedef void* WidgetHandle;
 
-// Descriptor passed to IPluginUIEvents::RegisterWidget.
 struct PluginWidgetDesc
 {
-	const char* name;                   // ImGui window title (must be globally unique)
+	const char* name;
 	PluginImGuiRenderCallback renderFn;
 };
 
-// Config-change notification — fired after the modloader UI writes a new value.
-// section / key: the INI section and key that changed.
-// newValue: the new value as a string (same representation as the INI file).
 typedef void (*PluginConfigChangedCallback)(const char* section, const char* key, const char* newValue);
 
-// ============================================================
-// IPluginUIEvents — UI registration (v16, client only)
-// Access via: hooks->UI->RegisterPanel(...)
-//             hooks->UI->RegisterWidget(...)
-// hooks->UI is nullptr on server and generic builds.
-// ============================================================
 struct IPluginUIEvents
 {
-	// Register a custom panel button + window.  desc must remain valid until Unregister.
-	// Returns a PanelHandle that uniquely identifies this panel.
-	// Store this handle — it is required for UnregisterPanel, SetPanelOpen, and SetPanelClose.
-	// Returns null if registration failed (duplicate title, null fields, UI disabled).
-	PanelHandle(*RegisterPanel)(const PluginPanelDesc* desc);
-	// Unregister a panel using the handle returned by RegisterPanel.  Call during PluginShutdown.
-	// Silently ignored if handle is null.
-	void (*UnregisterPanel)(PanelHandle handle);
-	// Receive a notification whenever the modloader UI writes a config value.
-	void (*RegisterOnConfigChanged)(PluginConfigChangedCallback callback);
-	void (*UnregisterOnConfigChanged)(PluginConfigChangedCallback callback);
-	// Open a registered panel window using the handle returned by RegisterPanel.
-	// Silently ignored if handle is null.
-	void (*SetPanelOpen)(PanelHandle handle);
-	// Close a registered panel window using the handle returned by RegisterPanel.
-	// Silently ignored if handle is null.
-	void (*SetPanelClose)(PanelHandle handle);
-	// Register an always-on widget window rendered every frame.
-	// desc and all strings it points to must remain valid until UnregisterWidget is called.
-	// Returns a WidgetHandle that uniquely identifies this widget.
-	// Returns null if registration failed (duplicate name, null fields, UI disabled).
-	WidgetHandle(*RegisterWidget)(const PluginWidgetDesc* desc);
-	// Unregister a widget using the handle returned by RegisterWidget.  Call during PluginShutdown.
-	// Silently ignored if handle is null.
-	void (*UnregisterWidget)(WidgetHandle handle);
-	// Show or hide a widget window.  Widgets are visible by default after registration.
-	// Use this to let players toggle a widget (e.g. via a keybind or config option).
-	// Silently ignored if handle is null.
-	void (*SetWidgetVisible)(WidgetHandle handle, bool visible);
+	PanelHandle  (*RegisterPanel)(const PluginPanelDesc* desc);
+	void         (*UnregisterPanel)(PanelHandle handle);
+	void         (*RegisterOnConfigChanged)(PluginConfigChangedCallback callback);
+	void         (*UnregisterOnConfigChanged)(PluginConfigChangedCallback callback);
+	void         (*SetPanelOpen)(PanelHandle handle);
+	void       (*SetPanelClose)(PanelHandle handle);
+	WidgetHandle (*RegisterWidget)(const PluginWidgetDesc* desc);      // v16
+	void      (*UnregisterWidget)(WidgetHandle handle);   // v16
+	void         (*SetWidgetVisible)(WidgetHandle handle, bool visible); // v16
 };
 
-// ============================================================
-// IPluginHUDEvents — HUD hook subscriptions (v16, client only)
-// Access via: hooks->HUD->RegisterOnPostRender(...)
-// hooks->HUD is nullptr on server and generic builds — always null-check before use.
-// ============================================================
 struct IPluginHUDEvents
 {
-	// Register a per-frame callback fired after AHUD::PostRender.
-	// The engine draws its own HUD before plugins are notified.
-	// hud is the raw AHUD* — cast to SDK::AHUD* inside your callback.
 	void      (*RegisterOnPostRender)(PluginHUDPostRenderCallback callback);
-	void      (*UnregisterOnPostRender)(PluginHUDPostRenderCallback callback);
-	// Resolved address of UCrMapManuSubsystem::GatherPlayersData, or 0 if not found.
-	// Cast to a function pointer and call with the subsystem instance to force an
-	// immediate refresh of PlayersMarkerDataContainer.
-	uintptr_t(*GetGatherPlayersDataAddress)();
+	void  (*UnregisterOnPostRender)(PluginHUDPostRenderCallback callback);
+	uintptr_t (*GetGatherPlayersDataAddress)();
 };
 
-// ============================================================
-// IPluginNetworkChannel — server-to-client plugin packet messaging (v17)
-// Access via: hooks->Network->SendPacketToClient(...)
-// hooks->Network is non-null on server AND client builds; nullptr on generic (Debug/Release) builds.
-// Always null-check hooks->Network before use.
-//
-// Packet payloads must be plain-old-data (POD) structs with no pointers, no vtables,
-// and no std containers.  The same plugin DLL running on both ends guarantees identical
-// struct layout so plain memcpy serialization works without a schema.
-//
-// Prefer the typed wrappers in plugin_network_helpers.h (SendPacketToPlayer<T>,
-// SendPacketToAllClients<T>, OnReceive<T>) over calling these functions directly.
-// ============================================================
+// ---------------------------------------------------------------------------
+// Network channel (v17–v18)
+// ---------------------------------------------------------------------------
 struct IPluginNetworkChannel
 {
-	// True when called from a server build; false on a client build.
 	bool (*IsServer)();
-
-	// Server-side: send a raw packet to a single player.
-	// playerController : the APlayerController* for the target player (cast to void*)
-	// self             : the calling plugin's IPluginSelf (name is used for packet routing)
-	// typeTag          : arbitrary string identifying the packet type
-	// data             : payload bytes; copied before the call returns
-	// size             : byte count of the payload (max ~1 KB recommended)
-	// No-op on client builds.
-	void (*SendPacketToClient)(void* playerController, const IPluginSelf* self,
-		const char* typeTag, const uint8_t* data, size_t size);
-
-	// Server-side: send a raw packet to all currently connected players.
-	// self / typeTag / data / size: same semantics as SendPacketToClient.
-	// No-op on client builds.
-	void (*SendPacketToAllClients)(const IPluginSelf* self, const char* typeTag,
-		const uint8_t* data, size_t size);
-
-	// Client-side: register a handler for packets arriving with the given self->name+typeTag pair.
-	// Multiple handlers for the same pair are supported.
-	// No-op on server builds.
-	void (*RegisterMessageHandler)(const IPluginSelf* self, const char* typeTag,
-		PluginNetworkMessageCallback callback);
-
-	// Client-side: unregister a previously registered handler.
-	// Silently ignored if the handler was not registered.
-	// No-op on server builds.
-	void (*UnregisterMessageHandler)(const IPluginSelf* self, const char* typeTag,
-		PluginNetworkMessageCallback callback);
-
-	// v18 -- Client-side: send a raw packet to the server.
-	// self / typeTag / data / size: same semantics as SendPacketToClient.
-	// Transport: ACrPlayerControllerBase::ServerChatCommit (NetServer RPC).
-	// No-op on server builds.
-	void (*SendPacketToServer)(const IPluginSelf* self, const char* typeTag,
-		const uint8_t* data, size_t size);
-
-	// v18 -- Server-side: register a handler for packets arriving from any client.
-	// callback receives the sender's APlayerController* (cast to void*) along with
-	// the standard pluginName/typeTag/data/size fields.
-	// No-op on client builds.
-	void (*RegisterServerMessageHandler)(const IPluginSelf* self, const char* typeTag,
-		PluginNetworkServerMessageCallback callback);
-
-	// v18 -- Server-side: unregister a previously registered server-message handler.
-	// Silently ignored if the handler was not registered.
-	// No-op on client builds.
-	void (*UnregisterServerMessageHandler)(const IPluginSelf* self, const char* typeTag,
-		PluginNetworkServerMessageCallback callback);
-
-	// v18 -- Server-only: exclude a PlayerController from SendPacketToAllClients sends.
-	// Intended for plugin-spawned controllers (e.g. fake/AI players) that have no real
-	// network connection.  Sending to them is a silent no-op anyway, but registering an
-	// exclusion avoids the wasted ProcessEvent call and log noise.
-	// No-op on client builds.  Passing null is a no-op.
-	void (*ExcludeFromBroadcast)(void* playerController);
-
-	// v18 -- Server-only: undo a previous ExcludeFromBroadcast registration.
-	// No-op on client builds or if the controller was not registered.
-	void (*UnexcludeFromBroadcast)(void* playerController);
+	void (*SendPacketToClient)(void* playerController, const IPluginSelf* self, const char* typeTag, const uint8_t* data, size_t size);
+	void (*SendPacketToAllClients)(const IPluginSelf* self, const char* typeTag, const uint8_t* data, size_t size);
+	void (*RegisterMessageHandler)(const IPluginSelf* self, const char* typeTag, PluginNetworkMessageCallback callback);
+	void (*UnregisterMessageHandler)(const IPluginSelf* self, const char* typeTag, PluginNetworkMessageCallback callback);
+	void (*SendPacketToServer)(const IPluginSelf* self, const char* typeTag, const uint8_t* data, size_t size);  // v18
+	void (*RegisterServerMessageHandler)(const IPluginSelf* self, const char* typeTag, PluginNetworkServerMessageCallback callback); // v18
+	void (*UnregisterServerMessageHandler)(const IPluginSelf* self, const char* typeTag, PluginNetworkServerMessageCallback callback); // v18
+	void (*ExcludeFromBroadcast)(void* playerController);    // v18
+	void (*UnexcludeFromBroadcast)(void* playerController);  // v18
 };
 
-// ============================================================
-// IPluginNativePointers — trampoline addresses for all managed hooks (v21)
-// Access via: hooks->NativePointers->EngineTick()
-//
-// Each function returns the address of the MinHook trampoline that calls
-// the original (unmodified) game function.  Returns 0 if the hook has not
-// been installed yet (lazy hooks that install on first callback registration
-// will return 0 until at least one callback is registered).
-//
-// USAGE EXAMPLE — calling the original UGameEngine::Tick directly:
-//   using Tick_t = void(__fastcall*)(void* engine, float dt, bool idle);
-//   auto originalTick = reinterpret_cast<Tick_t>(
-//       self->hooks->NativePointers->EngineTick());
-//   if (originalTick) originalTick(enginePtr, delta, false);
-//
-// All addresses are stable for the lifetime of the hook installation.
-// ============================================================
+// ---------------------------------------------------------------------------
+// Native pointers (v21)
+// ---------------------------------------------------------------------------
 struct IPluginNativePointers
 {
-	// --- Engine lifecycle ---
-	// FEngineLoop::Init  — int32_t(__fastcall*)(void* thisPtr)
-	uintptr_t(*EngineLoopInit)();
-	// UGameEngine::Init  — bool(__fastcall*)(void* thisPtr, void* InEngineLoop)
-	uintptr_t(*GameEngineInit)();
-	// FEngineLoop::Exit  — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*EngineLoopExit)();
-	// UEngine::PreExit   — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*EnginePreExit)();
-	// UGameEngine::Tick  — void(__fastcall*)(void* thisPtr, float deltaSeconds, bool bIdleMode)
-	uintptr_t(*EngineTick)();
-
-	// --- World events ---
-	// UCrSessionWorldLoaderSubsystem::OnWorldBeginPlay — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*WorldBeginPlay)();
-	// UWorld::EndPlay — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*WorldEndPlay)();
-
-	// --- Save / experience ---
-	// UCrMassSaveSubsystem::OnSaveLoaded — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*SaveLoaded)();
-	// UCrExperienceManagerComponent::OnExperienceLoadComplete — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*ExperienceLoadComplete)();
-
-	// --- Actor / player ---
-	// AActor::BeginPlay — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*ActorBeginPlay)();
-	// AGameModeBase::PostLogin — void(__fastcall*)(void* thisPtr, void* newPlayer)
-	uintptr_t(*PlayerJoined)();
-	// AGameModeBase::Logout — void(__fastcall*)(void* thisPtr, void* exiting)
-	uintptr_t(*PlayerLeft)();
-
-	// --- Spawners ---
-	// AAbstractMassEnemySpawner::ActivateSpawner — void(__fastcall*)(void* thisPtr, bool bDisableAggroLock)
-	uintptr_t(*SpawnerActivate)();
-	// AAbstractMassEnemySpawner::DeactivateSpawner — void(__fastcall*)(void* thisPtr, bool bPermanently)
-	uintptr_t(*SpawnerDeactivate)();
-	// AMassSpawner::DoSpawning — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*SpawnerDoSpawning)();
-
-	// --- Client only (nullptr on server/generic builds) ---
-	// AHUD::PostRender — void(__fastcall*)(void* thisPtr)
-	uintptr_t(*HUDPostRender)();
-	// ClientSaveStringToTxt ExecFunction — void(__fastcall*)(void* context, void* stack, void* result)
-	uintptr_t(*ClientMessageExec)();
+	uintptr_t (*EngineLoopInit)();
+	uintptr_t (*GameEngineInit)();
+	uintptr_t (*EngineLoopExit)();
+	uintptr_t (*EnginePreExit)();
+	uintptr_t (*EngineTick)();
+	uintptr_t (*WorldBeginPlay)();
+	uintptr_t (*WorldEndPlay)();
+	uintptr_t (*SaveLoaded)();
+	uintptr_t (*ExperienceLoadComplete)();
+	uintptr_t (*ActorBeginPlay)();
+	uintptr_t (*PlayerJoined)();
+	uintptr_t (*PlayerLeft)();
+	uintptr_t (*SpawnerActivate)();
+	uintptr_t (*SpawnerDeactivate)();
+	uintptr_t (*SpawnerDoSpawning)();
+	uintptr_t (*HUDPostRender)();   // client only (nullptr on server/generic)
+	uintptr_t (*ClientMessageExec)();  // client only (nullptr on server/generic)
 };
 
+// ---------------------------------------------------------------------------
+// HTTP server (v22, server only)
+// ---------------------------------------------------------------------------
+
+// HTTP verb reported to OnRawRequest filter callbacks.
+enum class HttpMethod : uint8_t
+{
+	Get = 0, Post = 1, Put = 2, Delete = 3,
+	Patch = 4, Options = 5, Head = 6, Other = 7,
+};
+
+// Return value for OnRawRequest filter callbacks.
+enum class HttpRequestAction : uint8_t
+{
+	Approve = 0, // Continue processing (route handlers, then original engine handler).
+	Deny    = 1, // Send 403 Forbidden; stop all further processing.
+};
+
+// Read-only snapshot of the incoming request. Pointers valid only for the callback duration.
+// body is NOT null-terminated — use bodyLen.
+struct PluginHttpRequest
+{
+	const char* url;     // UTF-8, null-terminated, e.g. "/remote/object/call"
+	const char* body;    // Raw body bytes; nullptr when bodyLen == 0
+	size_t      bodyLen;
+	HttpMethod  method;
+};
+
+// Signature for raw-request filter callbacks.
+typedef HttpRequestAction (*PluginHttpRequestFilterCallback)(const PluginHttpRequest* req);
+
+// ---------------------------------------------------------------------------
+// Raw-response routes (v22)
+//
+// A plugin-owned HTTP handler. The modloader calls the callback whenever an
+// incoming URL starts with /<pluginName>/<urlPrefix>/ (case-insensitive).
+// The plugin populates PluginHttpResponse to control what is sent back.
+// If the callback leaves body/bodyLen at zero, a 200 with an empty body is sent.
+// To send a non-200 status, set statusCode accordingly.
+// The callback is always called from the HTTP connection thread — do NOT block
+// indefinitely or access UObjects without proper synchronisation.
+// ---------------------------------------------------------------------------
+
+// Response descriptor filled by the plugin's route callback.
+// All fields must remain valid until the callback returns.
+// The modloader copies body bytes and the content-type string before returning.
+struct PluginHttpResponse
+{
+	int      statusCode;   // HTTP status code, e.g. 200, 404, 500. Default: 200.
+	const char* contentType;  // MIME type string, e.g. "application/json". Default: "text/plain".
+	const char* body; // Response body bytes. May be nullptr when bodyLen == 0.
+	size_t      bodyLen;      // Byte count of body. 0 produces an empty body.
+};
+
+// Callback signature for raw-response routes.
+// req  : read-only incoming request snapshot — same semantics as filter callbacks.
+// resp : output descriptor — plugin fills this before returning.
+//        All pointer fields in resp must stay valid until the function returns;
+// the modloader copies them immediately after.
+typedef void (*PluginHttpRouteCallback)(const PluginHttpRequest* req, PluginHttpResponse* resp);
+
 // ============================================================
-// IPluginHooks — top-level hook interface provided by the mod loader (v14)
-// Contains only typed sub-interface pointers. Access functionality via the
-// named group, e.g.:
-//   hooks->Engine->RegisterOnInit(&MyInit);
-//   hooks->Players->RegisterOnPlayerJoined(&MyJoinCb);
-//   hooks->Memory->Patch(addr, bytes, len);
-//   hooks->Hooks->Install(addr, detour, &original);
-//   hooks->Spawner->RegisterOnBeforeActivate(&MyBeforeCb);
-//   hooks->Input->RegisterKeybind(EModKey::F1, EModKeyEvent::Pressed, &MyKeyCb);
-//   hooks->HUD->RegisterOnPostRender(&MyPostRenderCb);  // client only, null-check first
-//   hooks->Network->SendPacketToAllClients(name, tag, data, size);  // server+client, null-check first
-//   hooks->Engine->PostToGameThread(&MyFn, ctx);         // any thread -> game thread (v18)
-//   hooks->NativePointers->EngineTick();                // trampoline addr (v21)
+// IPluginHttpServer — HTTP intercept interface (v22, server only)
+//
+// hooks->HttpServer is nullptr on client and generic builds.
+//
+// URL scheme:  /<pluginName>/<routeName>/...  (always case-insensitive)
+//   Static files:   /<self->name>/<folderName>/path/to/file.html
+//          → served from <exe_dir>\Plugins\<self->name>\<folderName>\
+//   Raw routes:     /<self->name>/<urlPrefix>/any/sub/path
+//          → callback receives the full original URL
+//
+// Processing order for every incoming request:
+//   1. Raw-request filters  — RegisterOnRawRequest / UnregisterOnRawRequest
+//        First Deny sends 403 and stops all further processing.
+//   2. Raw-response routes  — AddRawRoute / RemoveRawRoute
+//   Plugin-owned handler; plugin writes status, content-type, and body.
+//   3. Static-file routes   — AddRoute / RemoveRoute
+//        Files served from disk with a 200 and an inferred MIME type.
+//   4. Pass-through     — original engine handler (produces 404 for unknown paths).
 // ============================================================
+struct IPluginHttpServer
+{
+	// -----------------------------------------------------------------------
+	// Static-file routes
+	// -----------------------------------------------------------------------
+
+	// Register a static-file route.
+	// URL matched (case-insensitive): /<self->name>/<folderName>/...
+	// Files served from:     <exe_dir>\Plugins\<self->name>\<folderName>\
+	// Returns false if already registered or folderName is empty/null.
+	bool (*AddRoute)(const IPluginSelf* self, const char* folderName);
+
+	// Unregister a static-file route. No-op if not registered.
+	void (*RemoveRoute)(const IPluginSelf* self, const char* folderName);
+
+	// -----------------------------------------------------------------------
+	// Raw-request filters
+	// -----------------------------------------------------------------------
+
+	// Register a raw-request filter. Fires for every HTTP request before routes.
+	// Return Deny to send 403; return Approve to continue. First Deny wins.
+	void (*RegisterOnRawRequest)(PluginHttpRequestFilterCallback callback);
+
+	// Unregister a raw-request filter. No-op if not registered.
+	void (*UnregisterOnRawRequest)(PluginHttpRequestFilterCallback callback);
+
+	// -----------------------------------------------------------------------
+	// Raw-response routes (v22)
+	// -----------------------------------------------------------------------
+
+	// Register a plugin-owned HTTP handler.
+	// urlPrefix  : route name, e.g. "api".
+	// Matched URL (case-insensitive): /<self->name>/<urlPrefix>/...
+	// callback   : called when a matching request arrives; plugin fills PluginHttpResponse.
+	// Returns false if already registered or urlPrefix is empty/null.
+	bool (*AddRawRoute)(const IPluginSelf* self, const char* urlPrefix, PluginHttpRouteCallback callback);
+
+	// Unregister a previously added raw-response route. No-op if not registered.
+	// Always call during PluginShutdown to avoid dangling callback pointers.
+	void (*RemoveRawRoute)(const IPluginSelf* self, const char* urlPrefix);
+};
+
+// ---------------------------------------------------------------------------
+// Top-level hooks interface (v14+)
+// ---------------------------------------------------------------------------
 struct IPluginHooks
 {
-	IPluginSpawnerHooks* Spawner;        // v14 — enemy spawner Before/After hooks
-	IPluginHookUtils* Hooks;          // v14 — low-level hook install/remove/query
-	IPluginMemoryUtils* Memory; // v14 — memory patch/nop/read/alloc
-	IPluginEngineEvents* Engine;      // v14 — engine init/shutdown/tick subscriptions
-	IPluginWorldEvents* World;          // v14 — world begin-play / save / experience subscriptions
-	IPluginPlayerEvents* Players;        // v14 — player joined/left subscriptions
-	IPluginActorEvents* Actors;         // v14 — actor begin-play subscriptions
-	IPluginInputEvents* Input;   // v15 — keybind subscriptions (client only, null on server)
-	IPluginUIEvents* UI;    // v15 — custom panel registration + config-change callbacks (client only, null on server)
-	IPluginHUDEvents* HUD;         // v16 — AHUD::PostRender callbacks + HUD function addresses (client only, null on server)
-	IPluginNetworkChannel* Network;        // v17 — plugin-to-plugin net channel (server+client builds; null on generic)
-	IPluginNativePointers* NativePointers; // v21 — trampoline addresses for all managed hooks
+	IPluginSpawnerHooks*   Spawner;        // v14
+	IPluginHookUtils*  Hooks;    // v14
+	IPluginMemoryUtils*    Memory;         // v14
+	IPluginEngineEvents*   Engine;         // v14
+	IPluginWorldEvents*    World;          // v14
+	IPluginPlayerEvents* Players;        // v14
+	IPluginActorEvents*    Actors;       // v14
+	IPluginInputEvents*    Input;          // v15 — client only, null on server
+	IPluginUIEvents*  UI;          // v15 — client only, null on server
+	IPluginHUDEvents*      HUD;// v16 — client only, null on server
+	IPluginNetworkChannel* Network;   // v17 — server+client; null on generic
+	IPluginNativePointers* NativePointers; // v21
+	IPluginHttpServer*     HttpServer;     // v22 — server only, null on client/generic
 };
 
-// Plugin metadata structure
+// ---------------------------------------------------------------------------
+// Plugin metadata and identity
+// ---------------------------------------------------------------------------
 struct PluginInfo
 {
 	const char* name;
@@ -789,29 +494,20 @@ struct PluginInfo
 	int interfaceVersion;
 };
 
-// ============================================================
-// IPluginSelf — plugin identity + all service interfaces (v19)
-// Passed to PluginInit. The pointer is stable for the plugin's
-// entire lifetime — plugins may store it and use it for all
-// subsequent calls to logger, config, scanner, and hooks.
-// ============================================================
 struct IPluginSelf
 {
-	const char* name;     // from PluginInfo::name
-	const char* version;  // from PluginInfo::version
-	IPluginLogger* logger;
-	IPluginConfig* config;
+	const char*     name;
+	const char*     version;
+	IPluginLogger*  logger;
+	IPluginConfig*  config;
 	IPluginScanner* scanner;
-	IPluginHooks* hooks;
+	IPluginHooks*   hooks;
 };
 
-// Plugin interface - all plugins must implement these functions
-// These should be exported with extern "C" __declspec(dllexport)
 typedef PluginInfo* (*GetPluginInfoFunc)();
-typedef bool (*PluginInitFunc)(IPluginSelf* self);
-typedef void (*PluginShutdownFunc)();
+typedef bool        (*PluginInitFunc)(IPluginSelf* self);
+typedef void        (*PluginShutdownFunc)();
 
-// Function names that plugins must export
-#define PLUGIN_GET_INFO_FUNC_NAME "GetPluginInfo"
-#define PLUGIN_INIT_FUNC_NAME "PluginInit"
-#define PLUGIN_SHUTDOWN_FUNC_NAME "PluginShutdown"
+#define PLUGIN_GET_INFO_FUNC_NAME  "GetPluginInfo"
+#define PLUGIN_INIT_FUNC_NAME      "PluginInit"
+#define PLUGIN_SHUTDOWN_FUNC_NAME  "PluginShutdown"


### PR DESCRIPTION
Also has a API type, where u can serve raw json for example (plugin authors are intended to build the json payload themselves).  But this is useful for things like http://serverip:port/myplugin/api/players for example to return online players.

Port in this example is the server port, no additional port is required.

Note: `-RCWebControlDisable -RCWebInterfaceDisable` must not be defined for this to work, but worry not - ServerUtility patches the [vulnerability](https://wiki.starrupture-utilities.com/en/dedicated-server/Vulnerability-Announcement).

More info: https://github.com/AlienXAXS/StarRupture-ModLoader/blob/main/HttpServer.md