### PR TITLE
Better keybinds & Plugin Reload/Unload Fixes, Other Improvements

### DIFF
--- a/Version_Mod_Loader/UI/imgui_backend.cpp
+++ b/Version_Mod_Loader/UI/imgui_backend.cpp
@@ -162,12 +162,96 @@ static bool ShouldCaptureInput()
 }
 
 // ---------------------------------------------------------------------------
+// Keybind dispatch from WM messages
+//
+// Called for every key/mouse message before the game sees it.  Fires plugin
+// keybind callbacks and returns true if the message should be swallowed
+// (blocking mode -- return 0 from WndProc so UE5 never processes it).
+//
+// Works in ALL game states: main menu, loading screens, and in-game.
+// The UGameViewportClient::InputKey hook is responsible for the in-game
+// blocking path only; dispatch always originates here.
+// ---------------------------------------------------------------------------
+static bool DispatchKeybindMessage(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	using namespace Hooks::Input;
+
+	EModKey      mk    = EModKey::Unknown;
+	EModKeyEvent event = EModKeyEvent::Pressed;
+
+	switch (msg)
+	{
+	case WM_KEYDOWN:
+	case WM_SYSKEYDOWN:
+		// lParam bit 30: key was already down (auto-repeat) -- ignore repeats.
+		if (lParam & (1 << 30)) return false;
+		mk    = VKToModKey(static_cast<int>(wParam));
+		event = EModKeyEvent::Pressed;
+		break;
+
+	case WM_KEYUP:
+	case WM_SYSKEYUP:
+		mk    = VKToModKey(static_cast<int>(wParam));
+		event = EModKeyEvent::Released;
+		break;
+
+	case WM_LBUTTONDOWN: mk = EModKey::LeftMouseButton;   event = EModKeyEvent::Pressed;  break;
+	case WM_LBUTTONUP:   mk = EModKey::LeftMouseButton;   event = EModKeyEvent::Released; break;
+	case WM_RBUTTONDOWN: mk = EModKey::RightMouseButton;  event = EModKeyEvent::Pressed;  break;
+	case WM_RBUTTONUP:   mk = EModKey::RightMouseButton;  event = EModKeyEvent::Released; break;
+	case WM_MBUTTONDOWN: mk = EModKey::MiddleMouseButton; event = EModKeyEvent::Pressed;  break;
+	case WM_MBUTTONUP:   mk = EModKey::MiddleMouseButton; event = EModKeyEvent::Released; break;
+
+	case WM_XBUTTONDOWN:
+		mk    = (GET_XBUTTON_WPARAM(wParam) == XBUTTON1)
+		            ? EModKey::ThumbMouseButton
+		            : EModKey::ThumbMouseButton2;
+		event = EModKeyEvent::Pressed;
+		break;
+	case WM_XBUTTONUP:
+		mk    = (GET_XBUTTON_WPARAM(wParam) == XBUTTON1)
+		            ? EModKey::ThumbMouseButton
+		            : EModKey::ThumbMouseButton2;
+		event = EModKeyEvent::Released;
+		break;
+
+	default:
+		return false;
+	}
+
+	if (mk == EModKey::Unknown) return false;
+
+	// Do not fire standalone modifier keys as keybinds.
+	int vk = ModKeyToVK(mk);
+	if (vk == VK_LCONTROL || vk == VK_RCONTROL ||
+	    vk == VK_LSHIFT   || vk == VK_RSHIFT   ||
+	    vk == VK_LMENU    || vk == VK_RMENU)
+		return false;
+
+	EModKeyModifiers mods = SampleCurrentModifiers();
+
+	Dispatch(mk, event);
+	DispatchCombo(mk, mods, event);
+
+	// Tell the caller to swallow this message if blocking is enabled.
+	return ShouldBlock(mk, mods);
+}
+
+// ---------------------------------------------------------------------------
 // WndProc subclass -- forwards messages to ImGui, swallows input when UI open
 // ---------------------------------------------------------------------------
 static LRESULT CALLBACK HookedWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
 		return true;
+
+	// Dispatch plugin keybind callbacks and optionally swallow the message.
+	// Only fires when the modloader UI is not open (same gate as InputKey hook).
+	if (!ShouldCaptureInput())
+	{
+		if (DispatchKeybindMessage(msg, wParam, lParam))
+			return 0; // blocking -- swallow before UE5 sees it
+	}
 
 	if (ShouldCaptureInput())
 	{
@@ -1462,7 +1546,6 @@ namespace UI::ImGuiBackend
 	{
 		g_renderingReady = true;
 		LogToFile::Info("[ImGuiBackend] Rendering ready -- D3D12 init will proceed on next Present");
-		Hooks::InputHook::Install();
 	}
 
 	IModLoaderImGui* GetImGuiAPI()

--- a/Version_Mod_Loader/UI/imgui_backend.cpp
+++ b/Version_Mod_Loader/UI/imgui_backend.cpp
@@ -13,6 +13,7 @@
 #include "plugin_widget_registry.h"
 #include "hooks/hooks_common.h"
 #include "hooks/input/keybind_registry.h"
+#include "hooks/input/input_hook.h"
 #include "logging/log.h"
 #include "splash_window.h"
 
@@ -1408,6 +1409,7 @@ namespace UI::ImGuiBackend
 	void Shutdown()
 	{
 		g_shutdown = true;
+		Hooks::InputHook::Remove();
 
 		// Restore the original vtable entry.
 		if (g_vtableSlot && g_originalPresent)
@@ -1460,6 +1462,7 @@ namespace UI::ImGuiBackend
 	{
 		g_renderingReady = true;
 		LogToFile::Info("[ImGuiBackend] Rendering ready -- D3D12 init will proceed on next Present");
+		Hooks::InputHook::Install();
 	}
 
 	IModLoaderImGui* GetImGuiAPI()

--- a/Version_Mod_Loader/UI/modloader_window.cpp
+++ b/Version_Mod_Loader/UI/modloader_window.cpp
@@ -9,6 +9,7 @@
 #include "config/config_manager.h"
 #include "global_settings.h"
 #include "logging/log.h"
+#include "hooks/input/keybind_registry.h"
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -39,6 +40,16 @@ namespace UI::ModLoaderWindow
     };
     static std::vector<ConfigKV> s_configEntries;
     static int  s_lastConfigPlugin = -1;  // plugin index for cached entries
+
+    struct RebindState
+    {
+        bool active           = false;
+        char section[64]      = {};
+        char cfgKey[64]       = {};   // the INI key name (not keyboard key)
+        char pluginName[64]   = {};
+        bool waitingForRelease = false;
+    };
+    static RebindState s_rebind;
 
     // -----------------------------------------------------------------------
     // Helpers
@@ -94,7 +105,9 @@ namespace UI::ModLoaderWindow
     }
 
     // Write a changed value back to disk and fire config-change notifications.
-    static void CommitConfigChange(const char* pluginName, ConfigKV& kv)
+    static void CommitConfigChange(const char* pluginName, ConfigKV& kv,
+                                   const char* oldValue = nullptr,
+                                   const ConfigEntry* entry = nullptr)
     {
         wchar_t iniPath[MAX_PATH];
         if (!GetPluginIniPath(pluginName, iniPath, MAX_PATH)) return;
@@ -104,6 +117,14 @@ namespace UI::ModLoaderWindow
         swprintf_s(wkey, L"%S", kv.key);
         swprintf_s(wval, L"%S", kv.value);
         WritePrivateProfileStringW(wsec, wkey, wval, iniPath);
+
+        // If this is a Keybind entry and the value actually changed, live-rebind
+        // any active keybind registrations for this plugin.
+        if (entry && entry->type == ConfigValueType::Keybind &&
+            oldValue && strcmp(oldValue, kv.value) != 0)
+        {
+            Hooks::Input::UpdateKeybindByName(pluginName, oldValue, kv.value);
+        }
 
         UI::PluginPanelRegistry::FireConfigChanged(kv.section, kv.key, kv.value);
     }
@@ -297,6 +318,27 @@ namespace UI::ModLoaderWindow
             }
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
         }
+        else if (e && e->type == ConfigValueType::Keybind)
+        {
+            ImGui::TextUnformatted(kv.key);
+            ImGui::SameLine();
+            // Show the current binding as a disabled label
+            const char* bindLabel = (kv.value[0] != '\0') ? kv.value : "(none)";
+            ImGui::TextDisabled("%s", bindLabel);
+            ImGui::SameLine();
+            char rebindId[160];
+            snprintf(rebindId, sizeof(rebindId), "Rebind##rb_%s_%s", kv.section, kv.key);
+            if (ImGui::SmallButton(rebindId))
+            {
+                strncpy_s(s_rebind.section,    kv.section,    _TRUNCATE);
+                strncpy_s(s_rebind.cfgKey,     kv.key,        _TRUNCATE);
+                strncpy_s(s_rebind.pluginName, pluginName,    _TRUNCATE);
+                s_rebind.waitingForRelease = true;
+                s_rebind.active            = true;
+                ImGui::OpenPopup("##rebind_modal");
+            }
+            widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
+        }
         else
         {
             // String or no schema entry: raw text input (original behaviour)
@@ -328,6 +370,115 @@ namespace UI::ModLoaderWindow
             }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
                 ImGui::SetTooltip("Reset to default: %s", e->defaultValue);
+        }
+    }
+
+    // Returns true if the given VK is a modifier key (Ctrl/Shift/Alt left or right).
+    static bool IsModifierVK(int vk)
+    {
+        return vk == VK_LCONTROL || vk == VK_RCONTROL ||
+               vk == VK_LSHIFT   || vk == VK_RSHIFT   ||
+               vk == VK_LMENU    || vk == VK_RMENU;
+    }
+
+    static void RenderRebindModal()
+    {
+        if (!s_rebind.active)
+            return;
+
+        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+        ImGui::SetNextWindowSize(ImVec2(340, 110), ImGuiCond_Always);
+
+        if (ImGui::BeginPopupModal("##rebind_modal", nullptr,
+                                   ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar))
+        {
+            ImGui::TextUnformatted("Press a key (with optional Ctrl/Shift/Alt), or ESC to cancel.");
+            ImGui::Spacing();
+            ImGui::TextDisabled("Binding: %s / %s", s_rebind.section, s_rebind.cfgKey);
+            ImGui::Spacing();
+
+            // Phase 1: wait for all keys to be released so the button click doesn't register.
+            if (s_rebind.waitingForRelease)
+            {
+                bool anyDown = false;
+                for (int vk = 0x01; vk <= 0xFE; ++vk)
+                {
+                    if (GetAsyncKeyState(vk) & 0x8000) { anyDown = true; break; }
+                }
+                if (!anyDown)
+                    s_rebind.waitingForRelease = false;
+
+                ImGui::TextDisabled("(release keys...)");
+                ImGui::EndPopup();
+                return;
+            }
+
+            // Phase 2: ESC cancels.
+            if (GetAsyncKeyState(VK_ESCAPE) & 0x8000)
+            {
+                s_rebind.active = false;
+                ImGui::CloseCurrentPopup();
+                ImGui::EndPopup();
+                return;
+            }
+
+            // Show live modifier state as feedback while waiting for the base key.
+            EModKeyModifiers curMods = Hooks::Input::SampleCurrentModifiers();
+            {
+                char preview[64] = {};
+                if (curMods & EModKeyMod_Ctrl)  { if (preview[0]) strncat_s(preview, " + ", _TRUNCATE); strncat_s(preview, "Ctrl",  _TRUNCATE); }
+                if (curMods & EModKeyMod_Shift) { if (preview[0]) strncat_s(preview, " + ", _TRUNCATE); strncat_s(preview, "Shift", _TRUNCATE); }
+                if (curMods & EModKeyMod_Alt)   { if (preview[0]) strncat_s(preview, " + ", _TRUNCATE); strncat_s(preview, "Alt",   _TRUNCATE); }
+                if (preview[0])
+                    strncat_s(preview, " + ...", _TRUNCATE);
+                else
+                    strncpy_s(preview, "...", _TRUNCATE);
+                ImGui::Text("%s", preview);
+            }
+
+            // Phase 3: scan for a non-modifier key press.
+            for (int vk = 0x01; vk <= 0xFE; ++vk)
+            {
+                if (vk == VK_ESCAPE)      continue;
+                if (IsModifierVK(vk))     continue;
+                if (!(GetAsyncKeyState(vk) & 0x8000)) continue;
+
+                EModKey mk = Hooks::Input::VKToModKey(vk);
+                if (mk == EModKey::Unknown) continue;
+
+                // Build the combo string and write it to the config entry.
+                char comboStr[64];
+                Hooks::Input::FormatComboString(mk, curMods, comboStr, sizeof(comboStr));
+
+                for (auto& kv : s_configEntries)
+                {
+                    if (strcmp(kv.section, s_rebind.section) == 0 &&
+                        strcmp(kv.key, s_rebind.cfgKey) == 0)
+                    {
+                        char oldValue[256];
+                        strncpy_s(oldValue, kv.value, _TRUNCATE);
+                        strncpy_s(kv.value, comboStr, _TRUNCATE);
+
+                        // Find the schema entry so CommitConfigChange can trigger live-rebind.
+                        const ConfigSchema* schema = ModLoaderLogger::GetPluginSchema(s_rebind.pluginName);
+                        const ConfigEntry* schEntry = FindSchemaEntry(schema, kv.section, kv.key);
+                        CommitConfigChange(s_rebind.pluginName, kv, oldValue, schEntry);
+                        break;
+                    }
+                }
+
+                s_rebind.active = false;
+                ImGui::CloseCurrentPopup();
+                break;
+            }
+
+            ImGui::EndPopup();
+        }
+        else
+        {
+            // Popup was closed externally.
+            s_rebind.active = false;
         }
     }
 
@@ -405,6 +556,8 @@ namespace UI::ModLoaderWindow
                 }
             }
         }
+
+        RenderRebindModal();
 
         ImGui::EndChild();
     }

--- a/Version_Mod_Loader/UI/modloader_window.cpp
+++ b/Version_Mod_Loader/UI/modloader_window.cpp
@@ -55,6 +55,10 @@ namespace UI::ModLoaderWindow
     // Helpers
     // -----------------------------------------------------------------------
 
+    // Forward declaration (defined after RenderPluginsTab).
+    static const ConfigEntry* FindSchemaEntry(const ConfigSchema* schema,
+                                              const char* section, const char* key);
+
     // Build the absolute path to <pluginName>.ini under the config directory.
     static bool GetPluginIniPath(const char* pluginName, wchar_t* outPath, size_t outLen)
     {

--- a/Version_Mod_Loader/UI/modloader_window.cpp
+++ b/Version_Mod_Loader/UI/modloader_window.cpp
@@ -269,28 +269,40 @@ namespace UI::ModLoaderWindow
         return nullptr;
     }
 
-    // Render a single config row using type information from schema entry (may be null).
+    // Render one config row inside an already-open 3-column table:
+    //   Col 0 (Label)   -- setting name, description tooltip on hover
+    //   Col 1 (Widget)  -- the editable control, fills available width
+    //   Col 2 (Actions) -- blocking checkbox (keybind only) + reset button
     static void RenderConfigEntry(ConfigKV& kv, const ConfigEntry* e, const char* pluginName)
     {
+        ImGui::TableNextRow();
+
         char id[128];
         snprintf(id, sizeof(id), "##%s_%s", kv.section, kv.key);
 
-        // Show reset button for all entries except General.Enabled
         bool showReset = e && e->defaultValue && e->defaultValue[0] &&
                          !(strcmp(kv.section, "General") == 0 && strcmp(kv.key, "Enabled") == 0);
 
-        // Width to reserve for the reset button: frame height (square button) + spacing
-        float resetBtnW = ImGui::GetFrameHeight() + ImGui::GetStyle().ItemSpacing.x;
-        float inputWidth = showReset ? -resetBtnW : -1.0f;
+        // ---- Col 0: label ------------------------------------------------
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(kv.key);
+        if (e && e->description && e->description[0] &&
+            ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+            ImGui::SetTooltip("%s", e->description);
+
+        // ---- Col 1: widget -----------------------------------------------
+        ImGui::TableSetColumnIndex(1);
+        ImGui::SetNextItemWidth(-FLT_MIN); // fill the column
 
         bool widgetHovered = false;
 
         if (e && e->type == ConfigValueType::Boolean)
         {
             bool bval = (strcmp(kv.value, "true") == 0 || strcmp(kv.value, "1") == 0);
-            char label[128];
-            snprintf(label, sizeof(label), "%s%s", kv.key, id);
-            if (ImGui::Checkbox(label, &bval))
+            char lbl[128];
+            snprintf(lbl, sizeof(lbl), "##chk%s", id);
+            if (ImGui::Checkbox(lbl, &bval))
             {
                 strncpy_s(kv.value, bval ? "true" : "false", _TRUNCATE);
                 CommitConfigChange(pluginName, kv);
@@ -301,9 +313,6 @@ namespace UI::ModLoaderWindow
         {
             int ival = atoi(kv.value);
             bool hasRange = e->rangeMax > e->rangeMin;
-            ImGui::TextUnformatted(kv.key);
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(inputWidth);
             if (hasRange)
             {
                 if (ImGui::SliderInt(id, &ival, (int)e->rangeMin, (int)e->rangeMax))
@@ -330,9 +339,6 @@ namespace UI::ModLoaderWindow
         {
             float fval = strtof(kv.value, nullptr);
             bool hasRange = e->rangeMax > e->rangeMin;
-            ImGui::TextUnformatted(kv.key);
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(inputWidth);
             if (hasRange)
             {
                 if (ImGui::SliderFloat(id, &fval, e->rangeMin, e->rangeMax, "%.6g"))
@@ -357,66 +363,27 @@ namespace UI::ModLoaderWindow
         }
         else if (e && e->type == ConfigValueType::Keybind)
         {
-            ImGui::TextUnformatted(kv.key);
-            ImGui::SameLine();
-            // Show the current binding as a disabled label
+            // Current bind label + Rebind button, side by side, left-aligned.
             const char* bindLabel = (kv.value[0] != '\0') ? kv.value : "(none)";
+            ImGui::AlignTextToFramePadding();
             ImGui::TextDisabled("%s", bindLabel);
             ImGui::SameLine();
             char rebindId[160];
             snprintf(rebindId, sizeof(rebindId), "Rebind##rb_%s_%s", kv.section, kv.key);
             if (ImGui::SmallButton(rebindId))
             {
-                strncpy_s(s_rebind.section,    kv.section,    _TRUNCATE);
-                strncpy_s(s_rebind.cfgKey,     kv.key,        _TRUNCATE);
-                strncpy_s(s_rebind.pluginName, pluginName,    _TRUNCATE);
+                strncpy_s(s_rebind.section,    kv.section, _TRUNCATE);
+                strncpy_s(s_rebind.cfgKey,     kv.key,     _TRUNCATE);
+                strncpy_s(s_rebind.pluginName, pluginName, _TRUNCATE);
                 s_rebind.waitingForRelease = true;
                 s_rebind.active            = true;
                 ImGui::OpenPopup("##rebind_modal");
             }
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
-
-            // Blocking checkbox -- lets the user decide whether this keybind
-            // should consume the input (preventing the game from also reacting).
-            ImGui::SameLine();
-            {
-                wchar_t iniPath[MAX_PATH];
-                wchar_t wsec[64], wblkKey[128];
-                bool bBlocking = false;
-                if (GetPluginIniPath(pluginName, iniPath, MAX_PATH))
-                {
-                    swprintf_s(wsec, L"%S", kv.section);
-                    swprintf_s(wblkKey, L"%SBlocking", kv.key);
-                    bBlocking = (GetPrivateProfileIntW(wsec, wblkKey, 0, iniPath) != 0);
-                }
-                char chkId[160];
-                snprintf(chkId, sizeof(chkId), "Blocking##blk_%s_%s", kv.section, kv.key);
-                if (ImGui::Checkbox(chkId, &bBlocking))
-                {
-                    // Persist to INI
-                    wchar_t iniPath2[MAX_PATH];
-                    if (GetPluginIniPath(pluginName, iniPath2, MAX_PATH))
-                    {
-                        wchar_t wsec2[64], wblkKey2[128];
-                        swprintf_s(wsec2, L"%S", kv.section);
-                        swprintf_s(wblkKey2, L"%SBlocking", kv.key);
-                        WritePrivateProfileStringW(wsec2, wblkKey2, bBlocking ? L"1" : L"0", iniPath2);
-                    }
-                    // Apply to runtime blocking map
-                    Hooks::Input::SetComboBlocking(kv.value, bBlocking);
-                }
-                if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
-                    ImGui::SetTooltip("When ticked, this key combo is consumed by the plugin --\n"
-                                      "the game will not also react to it.\n"
-                                      "Enable if the key conflicts with a game action.");
-            }
         }
         else
         {
-            // String or no schema entry: raw text input (original behaviour)
-            ImGui::TextUnformatted(kv.key);
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(inputWidth);
+            // String or unknown schema entry: plain text input.
             if (ImGui::InputText(id, kv.value, sizeof(kv.value),
                                  ImGuiInputTextFlags_EnterReturnsTrue))
                 CommitConfigChange(pluginName, kv);
@@ -425,16 +392,50 @@ namespace UI::ModLoaderWindow
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
         }
 
-        // Description tooltip (captured before the reset button changes IsItemHovered)
         if (e && e->description && e->description[0] && widgetHovered)
             ImGui::SetTooltip("%s", e->description);
 
-        // Reset button
+        // ---- Col 2: actions ----------------------------------------------
+        ImGui::TableSetColumnIndex(2);
+
+        // Blocking checkbox (keybind rows only).
+        if (e && e->type == ConfigValueType::Keybind)
+        {
+            wchar_t iniPath[MAX_PATH];
+            bool bBlocking = false;
+            if (GetPluginIniPath(pluginName, iniPath, MAX_PATH))
+            {
+                wchar_t wsec[64], wblkKey[128];
+                swprintf_s(wsec,    L"%S",        kv.section);
+                swprintf_s(wblkKey, L"%SBlocking", kv.key);
+                bBlocking = (GetPrivateProfileIntW(wsec, wblkKey, 0, iniPath) != 0);
+            }
+            char chkId[160];
+            snprintf(chkId, sizeof(chkId), "##blk_%s_%s", kv.section, kv.key);
+            if (ImGui::Checkbox(chkId, &bBlocking))
+            {
+                wchar_t iniPath2[MAX_PATH];
+                if (GetPluginIniPath(pluginName, iniPath2, MAX_PATH))
+                {
+                    wchar_t wsec2[64], wblkKey2[128];
+                    swprintf_s(wsec2,    L"%S",        kv.section);
+                    swprintf_s(wblkKey2, L"%SBlocking", kv.key);
+                    WritePrivateProfileStringW(wsec2, wblkKey2, bBlocking ? L"1" : L"0", iniPath2);
+                }
+                Hooks::Input::SetComboBlocking(kv.value, bBlocking);
+            }
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+                ImGui::SetTooltip("Block: when ticked, this combo is consumed by the\n"
+                                  "plugin -- the game will not also react to it.\n"
+                                  "Enable if the key conflicts with a game action.");
+            ImGui::SameLine();
+        }
+
+        // Reset button.
         if (showReset)
         {
             char resetId[160];
             snprintf(resetId, sizeof(resetId), "R##r_%s_%s", kv.section, kv.key);
-            ImGui::SameLine();
             if (ImGui::SmallButton(resetId))
             {
                 strncpy_s(kv.value, e->defaultValue, _TRUNCATE);
@@ -613,19 +614,53 @@ namespace UI::ModLoaderWindow
                 ImGui::TextDisabled("Hover a setting for its description.  Changes are saved immediately.");
                 ImGui::Spacing();
 
+                // Actions column width: blocking checkbox + spacing + reset button.
+                // Sized to fit the widest possible content (keybind rows).
+                const float fh       = ImGui::GetFrameHeight();
+                const float spacing  = ImGui::GetStyle().ItemSpacing.x;
+                const float actionsW = fh + spacing + fh * 0.75f; // checkbox + R button
+
+                // One 3-column table per section so separators span full width
+                // and all rows within a section share the same column edges.
+                //   Col 0  Label   -- fixed 160px
+                //   Col 1  Widget  -- stretches to fill remaining space
+                //   Col 2  Actions -- fixed (blocking checkbox + reset)
+                const ImGuiTableFlags tblFlags =
+                    ImGuiTableFlags_BordersInnerH |
+                    ImGuiTableFlags_PadOuterX;
+
                 const char* curSection = nullptr;
+                bool        tableOpen  = false;
+
                 for (auto& kv : s_configEntries)
                 {
                     if (!curSection || strcmp(curSection, kv.section) != 0)
                     {
+                        if (tableOpen) { ImGui::EndTable(); tableOpen = false; }
                         if (curSection) ImGui::Spacing();
+
                         ImGui::SeparatorText(kv.section);
                         curSection = kv.section;
+
+                        char tblId[128];
+                        snprintf(tblId, sizeof(tblId), "##cfg_%s", kv.section);
+                        if (ImGui::BeginTable(tblId, 3, tblFlags))
+                        {
+                            ImGui::TableSetupColumn("##lbl",    ImGuiTableColumnFlags_WidthFixed,   160.0f);
+                            ImGui::TableSetupColumn("##widget", ImGuiTableColumnFlags_WidthStretch);
+                            ImGui::TableSetupColumn("##acts",   ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, actionsW);
+                            tableOpen = true;
+                        }
                     }
 
-                    const ConfigEntry* entry = FindSchemaEntry(schema, kv.section, kv.key);
-                    RenderConfigEntry(kv, entry, info->name);
+                    if (tableOpen)
+                    {
+                        const ConfigEntry* entry = FindSchemaEntry(schema, kv.section, kv.key);
+                        RenderConfigEntry(kv, entry, info->name);
+                    }
                 }
+
+                if (tableOpen) ImGui::EndTable();
             }
         }
 

--- a/Version_Mod_Loader/UI/modloader_window.cpp
+++ b/Version_Mod_Loader/UI/modloader_window.cpp
@@ -102,6 +102,26 @@ namespace UI::ModLoaderWindow
                 s_configEntries.push_back(entry);
             }
         }
+
+        // For each Keybind entry in the schema, read and apply the companion
+        // <key>Blocking flag so the runtime blocking state is always current
+        // when the config panel is opened.
+        const ConfigSchema* schema = ModLoaderLogger::GetPluginSchema(pluginName);
+        if (schema)
+        {
+            for (auto& kv : s_configEntries)
+            {
+                const ConfigEntry* schEntry = FindSchemaEntry(schema, kv.section, kv.key);
+                if (!schEntry || schEntry->type != ConfigValueType::Keybind) continue;
+                if (!kv.value[0]) continue;
+
+                wchar_t wsec[64], wblkKey[128];
+                swprintf_s(wsec, L"%S", kv.section);
+                swprintf_s(wblkKey, L"%SBlocking", kv.key);
+                bool blocking = (GetPrivateProfileIntW(wsec, wblkKey, 0, iniPath) != 0);
+                Hooks::Input::SetComboBlocking(kv.value, blocking);
+            }
+        }
     }
 
     // Write a changed value back to disk and fire config-change notifications.
@@ -119,10 +139,23 @@ namespace UI::ModLoaderWindow
         WritePrivateProfileStringW(wsec, wkey, wval, iniPath);
 
         // If this is a Keybind entry and the value actually changed, live-rebind
-        // any active keybind registrations for this plugin.
+        // any active keybind registrations for this plugin and transfer blocking state.
         if (entry && entry->type == ConfigValueType::Keybind &&
             oldValue && strcmp(oldValue, kv.value) != 0)
         {
+            // Transfer blocking state from the old combo to the new one.
+            // Read from INI (the ground truth) rather than the runtime map so this
+            // works correctly even if the map entry was never explicitly set.
+            {
+                wchar_t blkSec[64], wblkKey[128];
+                swprintf_s(blkSec, L"%S", kv.section);
+                swprintf_s(wblkKey, L"%SBlocking", kv.key);
+                bool wasBlocking = (GetPrivateProfileIntW(blkSec, wblkKey, 0, iniPath) != 0);
+                Hooks::Input::SetComboBlocking(kv.value, wasBlocking);
+                // Remove any stale entry for the old combo so it does not linger.
+                Hooks::Input::SetComboBlocking(oldValue, false);
+            }
+
             Hooks::Input::UpdateKeybindByName(pluginName, oldValue, kv.value);
         }
 
@@ -338,6 +371,41 @@ namespace UI::ModLoaderWindow
                 ImGui::OpenPopup("##rebind_modal");
             }
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
+
+            // Blocking checkbox -- lets the user decide whether this keybind
+            // should consume the input (preventing the game from also reacting).
+            ImGui::SameLine();
+            {
+                wchar_t iniPath[MAX_PATH];
+                wchar_t wsec[64], wblkKey[128];
+                bool bBlocking = false;
+                if (GetPluginIniPath(pluginName, iniPath, MAX_PATH))
+                {
+                    swprintf_s(wsec, L"%S", kv.section);
+                    swprintf_s(wblkKey, L"%SBlocking", kv.key);
+                    bBlocking = (GetPrivateProfileIntW(wsec, wblkKey, 0, iniPath) != 0);
+                }
+                char chkId[160];
+                snprintf(chkId, sizeof(chkId), "Blocking##blk_%s_%s", kv.section, kv.key);
+                if (ImGui::Checkbox(chkId, &bBlocking))
+                {
+                    // Persist to INI
+                    wchar_t iniPath2[MAX_PATH];
+                    if (GetPluginIniPath(pluginName, iniPath2, MAX_PATH))
+                    {
+                        wchar_t wsec2[64], wblkKey2[128];
+                        swprintf_s(wsec2, L"%S", kv.section);
+                        swprintf_s(wblkKey2, L"%SBlocking", kv.key);
+                        WritePrivateProfileStringW(wsec2, wblkKey2, bBlocking ? L"1" : L"0", iniPath2);
+                    }
+                    // Apply to runtime blocking map
+                    Hooks::Input::SetComboBlocking(kv.value, bBlocking);
+                }
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+                    ImGui::SetTooltip("When ticked, this key combo is consumed by the plugin --\n"
+                                      "the game will not also react to it.\n"
+                                      "Enable if the key conflicts with a game action.");
+            }
         }
         else
         {
@@ -736,6 +804,43 @@ namespace UI::ModLoaderWindow
     bool IsOpen()
     {
         return s_isOpen;
+    }
+
+    // Called by plugin_manager after each plugin's PluginInit completes so that
+    // blocking state is active from the very first key event, not deferred until
+    // the user opens the config panel for that plugin.
+    void LoadBlockingStateForPlugin(const char* pluginName)
+    {
+        if (!pluginName || !*pluginName) return;
+
+        wchar_t iniPath[MAX_PATH];
+        if (!GetPluginIniPath(pluginName, iniPath, MAX_PATH)) return;
+
+        const ConfigSchema* schema = ModLoaderLogger::GetPluginSchema(pluginName);
+        if (!schema) return;
+
+        for (int i = 0; i < schema->entryCount; ++i)
+        {
+            const ConfigEntry& e = schema->entries[i];
+            if (e.type != ConfigValueType::Keybind) continue;
+            if (!e.section || !e.key) continue;
+
+            // Read the current combo value from INI
+            wchar_t wsec[64], wkey[128], wblkKey[128];
+            swprintf_s(wsec, L"%S", e.section);
+            swprintf_s(wkey, L"%S", e.key);
+            swprintf_s(wblkKey, L"%SBlocking", e.key);
+
+            wchar_t comboW[256] = {};
+            GetPrivateProfileStringW(wsec, wkey, L"", comboW, ARRAYSIZE(comboW), iniPath);
+            if (!comboW[0]) continue;
+
+            char combo[256];
+            snprintf(combo, sizeof(combo), "%ls", comboW);
+
+            bool blocking = (GetPrivateProfileIntW(wsec, wblkKey, 0, iniPath) != 0);
+            Hooks::Input::SetComboBlocking(combo, blocking);
+        }
     }
 
     void Render(IModLoaderImGui* imgui)

--- a/Version_Mod_Loader/UI/modloader_window.h
+++ b/Version_Mod_Loader/UI/modloader_window.h
@@ -23,6 +23,12 @@ namespace UI::ModLoaderWindow
 
     // Returns true when the window is open (used to block game input).
     bool IsOpen();
+
+    // Called by plugin_manager after each plugin's PluginInit completes.
+    // Reads the plugin's INI and applies any <key>Blocking flags to the
+    // runtime blocking map so keybind suppression is active from the first
+    // key event, not deferred until the config panel is first opened.
+    void LoadBlockingStateForPlugin(const char* pluginName);
 }
 
 #endif // MODLOADER_CLIENT_BUILD

--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj
@@ -504,6 +504,7 @@
     <ClInclude Include="hooks\http\http_server_hook.h" />
     <ClInclude Include="hooks\input\keybind_registry.h" />
     <ClInclude Include="hooks\input\input_processor.h" />
+    <ClInclude Include="hooks\input\input_hook.h" />
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_internal.h" />
     <ClInclude Include="imgui\backends\imgui_impl_dx12.h" />
@@ -596,6 +597,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)' != 'Client Debug' And '$(Configuration)' != 'Client Release' And '$(Configuration)' != 'Local SDK Client Debug' And '$(Configuration)' != 'Local SDK Client Release'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="hooks\input\input_processor.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)' != 'Client Debug' And '$(Configuration)' != 'Client Release' And '$(Configuration)' != 'Local SDK Client Debug' And '$(Configuration)' != 'Local SDK Client Release'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="hooks\input\input_hook.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)' != 'Client Debug' And '$(Configuration)' != 'Client Release' And '$(Configuration)' != 'Local SDK Client Debug' And '$(Configuration)' != 'Local SDK Client Release'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="imgui\imgui.cpp">

--- a/Version_Mod_Loader/Version_Mod_Loader.vcxproj.filters
+++ b/Version_Mod_Loader/Version_Mod_Loader.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClInclude Include="hooks\input\input_processor.h">
       <Filter>Source Files\hooks\input</Filter>
     </ClInclude>
+    <ClInclude Include="hooks\input\input_hook.h">
+      <Filter>Source Files\hooks\input</Filter>
+    </ClInclude>
     <ClInclude Include="imgui\imgui.h">
       <Filter>Source Files\UI\imgui</Filter>
     </ClInclude>
@@ -336,6 +339,9 @@
       <Filter>Source Files\hooks\input</Filter>
     </ClCompile>
     <ClCompile Include="hooks\input\input_processor.cpp">
+      <Filter>Source Files\hooks\input</Filter>
+    </ClCompile>
+    <ClCompile Include="hooks\input\input_hook.cpp">
       <Filter>Source Files\hooks\input</Filter>
     </ClCompile>
     <ClCompile Include="hooks\memory\engine_allocator.cpp">

--- a/Version_Mod_Loader/config/config_manager.cpp
+++ b/Version_Mod_Loader/config/config_manager.cpp
@@ -479,8 +479,67 @@ namespace ModLoaderLogger
 			}
 		}
 
+		// Collect modloader-injected keys (e.g. <KeybindKey>Blocking) that are not
+		// in the plugin schema. WriteFormattedConfig only emits schema keys, so these
+		// would be silently dropped on every reformat without this rescue pass.
+		struct ExtraKV { std::wstring section, key, value; };
+		std::vector<ExtraKV> extraKeys;
+		{
+			wchar_t secBuf[4096] = {};
+			EnterCriticalSection(&g_configLock);
+			GetPrivateProfileSectionNamesW(secBuf, ARRAYSIZE(secBuf), configPath);
+			LeaveCriticalSection(&g_configLock);
+
+			for (const wchar_t* sec = secBuf; *sec; sec += wcslen(sec) + 1)
+			{
+				wchar_t kvBuf[8192] = {};
+				EnterCriticalSection(&g_configLock);
+				GetPrivateProfileSectionW(sec, kvBuf, ARRAYSIZE(kvBuf), configPath);
+				LeaveCriticalSection(&g_configLock);
+
+				for (const wchar_t* kv = kvBuf; *kv; kv += wcslen(kv) + 1)
+				{
+					const wchar_t* eq = wcschr(kv, L'=');
+					if (!eq) continue;
+					int keyLen = static_cast<int>(eq - kv);
+					// Only keep keys whose name ends in "Blocking"
+					static constexpr wchar_t kSuffix[] = L"Blocking";
+					static constexpr int kSuffixLen = 8;
+					if (keyLen <= kSuffixLen) continue;
+					if (wcsncmp(kv + keyLen - kSuffixLen, kSuffix, kSuffixLen) != 0) continue;
+
+					// Skip if it is already a schema entry (shouldn't happen, but be safe)
+					char narSec[64] = {}, narKey[128] = {};
+					snprintf(narSec, sizeof(narSec), "%ls", sec);
+					snprintf(narKey, sizeof(narKey), "%.*ls", keyLen, kv);
+					bool inSchema = false;
+					for (int i = 0; i < schema->entryCount && !inSchema; ++i)
+						if (_stricmp(schema->entries[i].section, narSec) == 0 &&
+						    _stricmp(schema->entries[i].key, narKey) == 0)
+							inSchema = true;
+					if (inSchema) continue;
+
+					ExtraKV ekv;
+					ekv.section = sec;
+					ekv.key     = std::wstring(kv, keyLen);
+					ekv.value   = eq + 1;
+					extraKeys.push_back(ekv);
+				}
+			}
+		}
+
 		FILETIME mtimeBefore = GetFileMtime(configPath);
 		WriteFormattedConfig(schema, configPath, &currentValues);
+
+		// Restore any extra *Blocking keys that were not part of the schema
+		if (!extraKeys.empty())
+		{
+			EnterCriticalSection(&g_configLock);
+			for (const auto& ekv : extraKeys)
+				WritePrivateProfileStringW(ekv.section.c_str(), ekv.key.c_str(), ekv.value.c_str(), configPath);
+			LeaveCriticalSection(&g_configLock);
+		}
+
 		FILETIME mtimeAfter = GetFileMtime(configPath);
 
 		bool fileChanged = (mtimeBefore.dwLowDateTime != mtimeAfter.dwLowDateTime ||

--- a/Version_Mod_Loader/core/init_thread.cpp
+++ b/Version_Mod_Loader/core/init_thread.cpp
@@ -17,6 +17,7 @@
 #ifdef MODLOADER_CLIENT_BUILD
 #include "../hooks/input/input_processor.h"
 #endif
+#include <hooks/input/input_hook.h>
 
 DWORD WINAPI MainInitThreadProc(LPVOID)
 {
@@ -50,6 +51,8 @@ DWORD WINAPI MainInitThreadProc(LPVOID)
 
     Hooks::WorldBeginPlay::Install();
     Hooks::EngineTick::Install();
+
+    Hooks::InputHook::Install();
 
     Splash::SetStatus(L"Checking for updates and installing hooks...");
     g_autoUpdateThread = CreateThread(nullptr, 0, AutoUpdateThreadProc, nullptr, 0, nullptr);

--- a/Version_Mod_Loader/hooks/game/scan_patterns.h
+++ b/Version_Mod_Loader/hooks/game/scan_patterns.h
@@ -16,6 +16,13 @@ namespace ScanPatterns
 	// Signature: void AHUD::PostRender()
 	inline constexpr auto AHUD_PostRender =
 		"40 55 53 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B D9 E8 ?? ?? ?? ?? 48 85 C0";
+
+	// UGameViewportClient::InputKey -- intercepts all keyboard/mouse input before UE5 processes it.
+	// Returning false (0) from our detour consumes the event (game will not react to it).
+	// Signature: __int64 __fastcall UGameViewportClient::InputKey(
+	//               UGameViewportClient* this, const FInputKeyEventArgs* InEventArgs)
+	inline constexpr auto UGameViewportClient_InputKey =
+		"48 8B C4 55 53 57 41 55 48 8D 68 ?? 48 81 EC ?? ?? ?? ?? 48 8B 5A";
 #endif
 
 	// UObject::ProcessEvent -- called for every UFUNCTION dispatch in the game.

--- a/Version_Mod_Loader/hooks/hooks_interface.cpp
+++ b/Version_Mod_Loader/hooks/hooks_interface.cpp
@@ -693,32 +693,54 @@ namespace ModLoaderLogger
 		         static_cast<unsigned>(key), static_cast<unsigned>(event));
 	}
 
-	static void HooksRegisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback)
+	static void HooksRegisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback)
 	{
-		if (!callback || !keyName)
+		if (!callback || !combo)
 		{
 			LogWarn(L"[HooksInterface] RegisterKeybindByName: null argument");
 			return;
 		}
-		Hooks::Input::RegisterKeybindByName(keyName, event, callback);
-		LogDebug(L"[HooksInterface] Keybind registered (name=%S, event=%u)",
-		         keyName, static_cast<unsigned>(event));
+		Hooks::Input::RegisterKeybindByName(combo, event, callback);
+		LogDebug(L"[HooksInterface] Keybind registered (combo=%S, event=%u)",
+		         combo, static_cast<unsigned>(event));
 	}
 
-	static void HooksUnregisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback)
+	static void HooksUnregisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback)
 	{
-		if (!callback || !keyName) return;
-		Hooks::Input::UnregisterKeybindByName(keyName, event, callback);
-		LogDebug(L"[HooksInterface] Keybind unregistered (name=%S, event=%u)",
-		         keyName, static_cast<unsigned>(event));
+		if (!callback || !combo) return;
+		Hooks::Input::UnregisterKeybindByName(combo, event, callback);
+		LogDebug(L"[HooksInterface] Keybind unregistered (combo=%S, event=%u)",
+		         combo, static_cast<unsigned>(event));
 	}
 
-	// Input sub-interface struct (v15)
+	static void HooksRegisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback)
+	{
+		if (!callback)
+		{
+			LogWarn(L"[HooksInterface] RegisterKeybindCombo: null callback");
+			return;
+		}
+		Hooks::Input::RegisterKeybindCombo(key, mods, event, callback);
+		LogDebug(L"[HooksInterface] Combo keybind registered (key=%u, mods=%u, event=%u)",
+		         static_cast<unsigned>(key), static_cast<unsigned>(mods), static_cast<unsigned>(event));
+	}
+
+	static void HooksUnregisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback)
+	{
+		if (!callback) return;
+		Hooks::Input::UnregisterKeybindCombo(key, mods, event, callback);
+		LogDebug(L"[HooksInterface] Combo keybind unregistered (key=%u, mods=%u, event=%u)",
+		         static_cast<unsigned>(key), static_cast<unsigned>(mods), static_cast<unsigned>(event));
+	}
+
+	// Input sub-interface struct (v15, extended v28/v29)
 	static IPluginInputEvents g_inputEvents = {
 		HooksRegisterKeybind,
 		HooksUnregisterKeybind,
-		HooksRegisterKeybindByName,
-		HooksUnregisterKeybindByName
+		HooksRegisterKeybindByName,   // v29: now handles plain keys and combos transparently
+		HooksUnregisterKeybindByName,
+		HooksRegisterKeybindCombo,    // v28: advanced — enum + mods, callback receives mods
+		HooksUnregisterKeybindCombo   // v28
 	};
 
 	// --- UI sub-interface wrappers (v15, client only) ---

--- a/Version_Mod_Loader/hooks/input/input_hook.cpp
+++ b/Version_Mod_Loader/hooks/input/input_hook.cpp
@@ -1,0 +1,208 @@
+#include "pch.h"
+#include "input_hook.h"
+
+// Client-only feature.
+#ifdef MODLOADER_CLIENT_BUILD
+
+#include "keybind_registry.h"
+#include "hooks/hooks_common.h"
+#include "hooks/game/scan_patterns.h"
+#include "memory_scanner/scanner.h"
+#include "UI/modloader_window.h"
+#include "logging/logger.h"
+
+#include <windows.h>
+#include <unordered_map>
+#include <mutex>
+
+namespace Hooks::InputHook
+{
+    // -----------------------------------------------------------------------
+    // UGameViewportClient::InputKey signature
+    // __int64 __fastcall InputKey(UGameViewportClient* This,
+    //                             const FInputKeyEventArgs* InEventArgs)
+    // Returns false (0) to consume the input; true (non-zero) to pass it on.
+    // -----------------------------------------------------------------------
+    using InputKey_t = __int64(__fastcall*)(void* This, const void* InEventArgs);
+
+    static Hook          g_hook;
+    static InputKey_t    g_original = nullptr;
+
+    // -----------------------------------------------------------------------
+    // FInputKeyEventArgs field offsets (UE5)
+    //   +0x00  FViewport*    Viewport
+    //   +0x08  int32         ControllerId
+    //   +0x0C  uint8[4]      padding
+    //   +0x10  FKey          Key  <- FName ComparisonIndex (uint32) at +0x10
+    //   +0x28  EInputEvent   Event  (0=Pressed, 1=Released, 2=Repeat)
+    //   +0x2C  float         AmountDepressed
+    //   +0x30  bool          bGamepad
+    // -----------------------------------------------------------------------
+    static constexpr int ARGS_FNAME_IDX_OFFSET = 0x10;  // uint32
+    static constexpr int ARGS_EVENT_OFFSET      = 0x28;  // int32 / enum
+
+    enum class EInputEvent : int32_t
+    {
+        Pressed  = 0,
+        Released = 1,
+        Repeat   = 2,
+    };
+
+    // -----------------------------------------------------------------------
+    // FName -> EModKey lazy cache
+    // On Pressed events we scan GetAsyncKeyState to find which VK is down,
+    // map it to an EModKey, and cache the FName ComparisonIndex.
+    // On Released events the key is already up so we rely on the cache.
+    // -----------------------------------------------------------------------
+    static std::unordered_map<uint32_t, EModKey> s_fnameCache;
+    static std::mutex                            s_fnameMutex;
+
+    static EModKey LookupFNameCache(uint32_t fnameIdx)
+    {
+        std::lock_guard<std::mutex> lock(s_fnameMutex);
+        auto it = s_fnameCache.find(fnameIdx);
+        if (it != s_fnameCache.end())
+            return it->second;
+        return EModKey::Unknown;
+    }
+
+    static void CacheFName(uint32_t fnameIdx, EModKey mk)
+    {
+        std::lock_guard<std::mutex> lock(s_fnameMutex);
+        s_fnameCache[fnameIdx] = mk;
+    }
+
+    // Scan the VK table for a key that is currently physically held.
+    // Called only on Pressed events (key still down when hook fires).
+    static EModKey ScanVKTableForDownKey()
+    {
+        auto activeKeys = Hooks::Input::GetActiveKeys();
+        for (auto& kv : activeKeys)
+        {
+            if (GetAsyncKeyState(kv.second) & 0x8000)
+                return kv.first;
+        }
+        return EModKey::Unknown;
+    }
+
+    // Returns true if the VK code belongs to a modifier key.
+    static bool IsModifierVK(int vk)
+    {
+        return vk == VK_LCONTROL || vk == VK_RCONTROL ||
+               vk == VK_LSHIFT   || vk == VK_RSHIFT   ||
+               vk == VK_LMENU    || vk == VK_RMENU;
+    }
+
+    // -----------------------------------------------------------------------
+    // Detour
+    // -----------------------------------------------------------------------
+    static __int64 __fastcall Detour(void* This, const void* InEventArgs)
+    {
+        if (!InEventArgs)
+            return g_original ? g_original(This, InEventArgs) : 0;
+
+        const uint8_t* args = static_cast<const uint8_t*>(InEventArgs);
+
+        EInputEvent ueEvent = *reinterpret_cast<const EInputEvent*>(args + ARGS_EVENT_OFFSET);
+
+        // Ignore key repeat events entirely -- we only care about edges.
+        if (ueEvent == EInputEvent::Repeat)
+            return g_original ? g_original(This, InEventArgs) : 0;
+
+        EModKeyEvent modEvent = (ueEvent == EInputEvent::Pressed)
+                                    ? EModKeyEvent::Pressed
+                                    : EModKeyEvent::Released;
+
+        uint32_t fnameIdx = *reinterpret_cast<const uint32_t*>(args + ARGS_FNAME_IDX_OFFSET);
+
+        // Resolve FName index to EModKey.
+        EModKey mk = LookupFNameCache(fnameIdx);
+        if (mk == EModKey::Unknown)
+        {
+            if (modEvent == EModKeyEvent::Pressed)
+            {
+                mk = ScanVKTableForDownKey();
+                if (mk != EModKey::Unknown)
+                    CacheFName(fnameIdx, mk);
+            }
+            else
+            {
+                // Released for an unknown key — just pass through.
+                return g_original ? g_original(This, InEventArgs) : 0;
+            }
+        }
+
+        if (mk == EModKey::Unknown)
+            return g_original ? g_original(This, InEventArgs) : 0;
+
+        // Do not dispatch modifier keys (Ctrl/Shift/Alt) as standalone keybinds.
+        int vk = Hooks::Input::ModKeyToVK(mk);
+        if (IsModifierVK(vk))
+            return g_original ? g_original(This, InEventArgs) : 0;
+
+        // Sample current modifier mask.
+        EModKeyModifiers mods = Hooks::Input::SampleCurrentModifiers();
+
+        // While the modloader UI is open, suppress all plugin keybind dispatch
+        // to prevent accidental keybind fires while interacting with the UI.
+        if (!UI::ModLoaderWindow::IsOpen())
+        {
+            Hooks::Input::Dispatch(mk, modEvent);
+            Hooks::Input::DispatchCombo(mk, mods, modEvent);
+
+            if (Hooks::Input::ShouldBlock(mk, mods))
+            {
+                // Return false (0) -- UE5 treats that as "input consumed".
+                return 0;
+            }
+        }
+
+        return g_original ? g_original(This, InEventArgs) : 0;
+    }
+
+    // -----------------------------------------------------------------------
+    // Install / Remove
+    // -----------------------------------------------------------------------
+    void Install()
+    {
+        ModLoaderLogger::LogInfo(L"[InputHook] Installing UGameViewportClient::InputKey hook...");
+
+        uintptr_t addr = Scanner::FindPatternInMainModule(
+            "UGameViewportClient::InputKey",
+            ScanPatterns::UGameViewportClient_InputKey);
+
+        if (!addr)
+        {
+            ModLoaderLogger::LogError(L"[InputHook] Pattern scan failed -- InputKey hook not installed");
+            return;
+        }
+
+        ModLoaderLogger::LogDebug(L"[InputHook] Found InputKey at 0x%llX", (unsigned long long)addr);
+
+        void* originalOut = nullptr;
+        if (!g_hook.Install(addr, reinterpret_cast<void*>(&Detour), &originalOut))
+        {
+            ModLoaderLogger::LogError(L"[InputHook] Hook install failed");
+            return;
+        }
+
+        g_original = reinterpret_cast<InputKey_t>(originalOut);
+        ModLoaderLogger::LogInfo(L"[InputHook] UGameViewportClient::InputKey hook installed");
+    }
+
+    void Remove()
+    {
+        g_hook.Remove();
+        g_original = nullptr;
+
+        {
+            std::lock_guard<std::mutex> lock(s_fnameMutex);
+            s_fnameCache.clear();
+        }
+
+        ModLoaderLogger::LogInfo(L"[InputHook] UGameViewportClient::InputKey hook removed");
+    }
+
+} // namespace Hooks::InputHook
+
+#endif // MODLOADER_CLIENT_BUILD

--- a/Version_Mod_Loader/hooks/input/input_hook.cpp
+++ b/Version_Mod_Loader/hooks/input/input_hook.cpp
@@ -8,7 +8,6 @@
 #include "hooks/hooks_common.h"
 #include "hooks/game/scan_patterns.h"
 #include "memory_scanner/scanner.h"
-#include "UI/modloader_window.h"
 #include "logging/logger.h"
 
 #include <windows.h>
@@ -50,9 +49,12 @@ namespace Hooks::InputHook
 
     // -----------------------------------------------------------------------
     // FName -> EModKey lazy cache
-    // On Pressed events we scan GetAsyncKeyState to find which VK is down,
-    // map it to an EModKey, and cache the FName ComparisonIndex.
-    // On Released events the key is already up so we rely on the cache.
+    // Dispatch already happened in HookedWndProc (covers all game states).
+    // This hook only needs to resolve the key in order to check ShouldBlock
+    // and return false (0) to consume the input from the UE5 input stack.
+    //
+    // On Pressed events we scan GetAsyncKeyState to identify the VK and cache
+    // the FName ComparisonIndex.  On Released events we use the warm cache.
     // -----------------------------------------------------------------------
     static std::unordered_map<uint32_t, EModKey> s_fnameCache;
     static std::mutex                            s_fnameMutex;
@@ -72,8 +74,6 @@ namespace Hooks::InputHook
         s_fnameCache[fnameIdx] = mk;
     }
 
-    // Scan the VK table for a key that is currently physically held.
-    // Called only on Pressed events (key still down when hook fires).
     static EModKey ScanVKTableForDownKey()
     {
         auto activeKeys = Hooks::Input::GetActiveKeys();
@@ -85,16 +85,13 @@ namespace Hooks::InputHook
         return EModKey::Unknown;
     }
 
-    // Returns true if the VK code belongs to a modifier key.
-    static bool IsModifierVK(int vk)
-    {
-        return vk == VK_LCONTROL || vk == VK_RCONTROL ||
-               vk == VK_LSHIFT   || vk == VK_RSHIFT   ||
-               vk == VK_LMENU    || vk == VK_RMENU;
-    }
-
     // -----------------------------------------------------------------------
-    // Detour
+    // Detour -- blocking only
+    //
+    // Keybind callbacks are dispatched in HookedWndProc which fires for every
+    // key message in all game states (main menu, loading screen, in-game).
+    // This detour's sole job is to return false (0) when the key is marked
+    // as blocking, consuming it from UE5's input stack.
     // -----------------------------------------------------------------------
     static __int64 __fastcall Detour(void* This, const void* InEventArgs)
     {
@@ -105,57 +102,27 @@ namespace Hooks::InputHook
 
         EInputEvent ueEvent = *reinterpret_cast<const EInputEvent*>(args + ARGS_EVENT_OFFSET);
 
-        // Ignore key repeat events entirely -- we only care about edges.
-        if (ueEvent == EInputEvent::Repeat)
+        // Only act on Pressed edges -- that is all we need for blocking.
+        if (ueEvent != EInputEvent::Pressed)
             return g_original ? g_original(This, InEventArgs) : 0;
-
-        EModKeyEvent modEvent = (ueEvent == EInputEvent::Pressed)
-                                    ? EModKeyEvent::Pressed
-                                    : EModKeyEvent::Released;
 
         uint32_t fnameIdx = *reinterpret_cast<const uint32_t*>(args + ARGS_FNAME_IDX_OFFSET);
 
-        // Resolve FName index to EModKey.
         EModKey mk = LookupFNameCache(fnameIdx);
         if (mk == EModKey::Unknown)
         {
-            if (modEvent == EModKeyEvent::Pressed)
-            {
-                mk = ScanVKTableForDownKey();
-                if (mk != EModKey::Unknown)
-                    CacheFName(fnameIdx, mk);
-            }
-            else
-            {
-                // Released for an unknown key — just pass through.
-                return g_original ? g_original(This, InEventArgs) : 0;
-            }
+            mk = ScanVKTableForDownKey();
+            if (mk != EModKey::Unknown)
+                CacheFName(fnameIdx, mk);
         }
 
         if (mk == EModKey::Unknown)
             return g_original ? g_original(This, InEventArgs) : 0;
 
-        // Do not dispatch modifier keys (Ctrl/Shift/Alt) as standalone keybinds.
-        int vk = Hooks::Input::ModKeyToVK(mk);
-        if (IsModifierVK(vk))
-            return g_original ? g_original(This, InEventArgs) : 0;
-
-        // Sample current modifier mask.
         EModKeyModifiers mods = Hooks::Input::SampleCurrentModifiers();
 
-        // While the modloader UI is open, suppress all plugin keybind dispatch
-        // to prevent accidental keybind fires while interacting with the UI.
-        if (!UI::ModLoaderWindow::IsOpen())
-        {
-            Hooks::Input::Dispatch(mk, modEvent);
-            Hooks::Input::DispatchCombo(mk, mods, modEvent);
-
-            if (Hooks::Input::ShouldBlock(mk, mods))
-            {
-                // Return false (0) -- UE5 treats that as "input consumed".
-                return 0;
-            }
-        }
+        if (Hooks::Input::ShouldBlock(mk, mods))
+            return 0; // consumed -- UE5 never processes this key
 
         return g_original ? g_original(This, InEventArgs) : 0;
     }

--- a/Version_Mod_Loader/hooks/input/input_hook.h
+++ b/Version_Mod_Loader/hooks/input/input_hook.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Client-only: UGameViewportClient::InputKey detour.
+// Intercepts all key events before UE5 processes them, fires plugin keybind
+// callbacks, and optionally consumes the input (blocking mode).
+
+#ifdef MODLOADER_CLIENT_BUILD
+
+namespace Hooks::InputHook
+{
+    // AOB scan + install the InputKey detour.
+    // Called from ImGuiBackend::SetRenderingReady() once the D3D12 overlay is live.
+    void Install();
+
+    // Uninstall the detour and clear the FName cache.
+    // Called from ImGuiBackend::Shutdown().
+    void Remove();
+}
+
+#endif // MODLOADER_CLIENT_BUILD

--- a/Version_Mod_Loader/hooks/input/input_processor.cpp
+++ b/Version_Mod_Loader/hooks/input/input_processor.cpp
@@ -21,8 +21,23 @@ namespace Hooks::Input
 	// -----------------------------------------------------------------------
 	// Per-frame poll callback — registered into the engine tick
 	// -----------------------------------------------------------------------
+
+	// Returns true if a window belonging to this process is in the foreground.
+	// Prevents keybind callbacks from firing when the player alt-tabs away.
+	static bool IsGameFocused()
+	{
+		HWND fg = GetForegroundWindow();
+		if (!fg) return false;
+		DWORD pid = 0;
+		GetWindowThreadProcessId(fg, &pid);
+		return pid == GetCurrentProcessId();
+	}
+
 	static void OnEngineTick(float /*deltaSeconds*/)
 	{
+		if (!IsGameFocused())
+			return;
+
 		// Retrieve the set of keys that have at least one registered callback.
 		// This is rebuilt each tick so newly registered keys are picked up immediately.
 		auto activeKeys = GetActiveKeys();
@@ -46,13 +61,17 @@ namespace Hooks::Input
 			{
 				// Key just went down — fire Pressed callbacks
 				ModLoaderLogger::LogDebug(L"[InputProcessor] Key pressed: VK=0x%02X, EModKey=%d", vk, key);
+				EModKeyModifiers mods = SampleCurrentModifiers();
 				Dispatch(key, EModKeyEvent::Pressed);
+				DispatchCombo(key, mods, EModKeyEvent::Pressed);
 			}
 			else if (!isDown && wasDown)
 			{
 				// Key just came up — fire Released callbacks
 				ModLoaderLogger::LogDebug(L"[InputProcessor] Key released: VK=0x%02X, EModKey=%d", vk, key);
+				EModKeyModifiers mods = SampleCurrentModifiers();
 				Dispatch(key, EModKeyEvent::Released);
+				DispatchCombo(key, mods, EModKeyEvent::Released);
 			}
 
 			s_prevKeyState[vk] = isDown;

--- a/Version_Mod_Loader/hooks/input/input_processor.cpp
+++ b/Version_Mod_Loader/hooks/input/input_processor.cpp
@@ -1,102 +1,33 @@
 #include "pch.h"
 #include "input_processor.h"
 #include "keybind_registry.h"
-#include "hooks/game/engine_tick/engine_tick.h"
 #include "logging/logger.h"
 
-#include <windows.h>
-#include <map>
-
-// Client-only feature — entire translation unit is a no-op on server/generic builds.
+// Client-only feature -- entire translation unit is a no-op on server/generic builds.
 #ifdef MODLOADER_CLIENT_BUILD
 
 namespace Hooks::Input
 {
-	// -----------------------------------------------------------------------
-	// Per-key state tracking
-	// -----------------------------------------------------------------------
-	// Maps VK code -> true if the key was down at the end of the previous tick.
-	static std::map<int, bool> s_prevKeyState;
+    // -----------------------------------------------------------------------
+    // Install / Remove
+    //
+    // Key dispatch now flows through the UGameViewportClient::InputKey hook
+    // (input_hook.cpp) rather than a GetAsyncKeyState polling loop on the
+    // engine tick.  These stubs retain the same public interface so call sites
+    // elsewhere in the codebase (hooks_interface, imgui_backend) do not change.
+    // -----------------------------------------------------------------------
+    void InstallInputProcessor()
+    {
+        Initialize(); // ensure registry tables are ready
+        ModLoaderLogger::LogInfo(L"[InputProcessor] Keybind registry initialised (dispatch via InputKey hook)");
+    }
 
-	// -----------------------------------------------------------------------
-	// Per-frame poll callback — registered into the engine tick
-	// -----------------------------------------------------------------------
+    void RemoveInputProcessor()
+    {
+        Shutdown(); // clear all registered keybinds
+        ModLoaderLogger::LogInfo(L"[InputProcessor] Keybind registry shut down");
+    }
 
-	// Returns true if a window belonging to this process is in the foreground.
-	// Prevents keybind callbacks from firing when the player alt-tabs away.
-	static bool IsGameFocused()
-	{
-		HWND fg = GetForegroundWindow();
-		if (!fg) return false;
-		DWORD pid = 0;
-		GetWindowThreadProcessId(fg, &pid);
-		return pid == GetCurrentProcessId();
-	}
-
-	static void OnEngineTick(float /*deltaSeconds*/)
-	{
-		if (!IsGameFocused())
-			return;
-
-		// Retrieve the set of keys that have at least one registered callback.
-		// This is rebuilt each tick so newly registered keys are picked up immediately.
-		auto activeKeys = GetActiveKeys();
-
-		for (auto& kv : activeKeys)
-		{
-			EModKey key = kv.first;
-			int vk = kv.second;
-
-			// GetAsyncKeyState: high bit set = key is currently pressed.
-			bool isDown = (GetAsyncKeyState(vk) & 0x8000) != 0;
-			bool wasDown = false;
-
-			auto it = s_prevKeyState.find(vk);
-			if (it != s_prevKeyState.end())
-				wasDown = it->second;
-			else
-				s_prevKeyState[vk] = false;
-
-			if (isDown && !wasDown)
-			{
-				// Key just went down — fire Pressed callbacks
-				ModLoaderLogger::LogDebug(L"[InputProcessor] Key pressed: VK=0x%02X, EModKey=%d", vk, key);
-				EModKeyModifiers mods = SampleCurrentModifiers();
-				Dispatch(key, EModKeyEvent::Pressed);
-				DispatchCombo(key, mods, EModKeyEvent::Pressed);
-			}
-			else if (!isDown && wasDown)
-			{
-				// Key just came up — fire Released callbacks
-				ModLoaderLogger::LogDebug(L"[InputProcessor] Key released: VK=0x%02X, EModKey=%d", vk, key);
-				EModKeyModifiers mods = SampleCurrentModifiers();
-				Dispatch(key, EModKeyEvent::Released);
-				DispatchCombo(key, mods, EModKeyEvent::Released);
-			}
-
-			s_prevKeyState[vk] = isDown;
-		}
-	}
-
-	// -----------------------------------------------------------------------
-	// Install / Remove
-	// -----------------------------------------------------------------------
-	void InstallInputProcessor()
-	{
-		Initialize(); // ensure registry tables are ready
-
-		ModLoaderLogger::LogDebug(L"[InputProcessor] Installing input processor, registering engine tick callback");
-		Hooks::EngineTick::RegisterPluginCallback(OnEngineTick);
-		ModLoaderLogger::LogInfo(L"[InputProcessor] Engine tick callback registered (keybind polling active)");
-	}
-
-	void RemoveInputProcessor()
-	{
-		Hooks::EngineTick::UnregisterPluginCallback(OnEngineTick);
-		s_prevKeyState.clear();
-		Shutdown(); // clear all registered keybinds
-		ModLoaderLogger::LogInfo(L"[InputProcessor] Engine tick callback unregistered");
-	}
 } // namespace Hooks::Input
 
 #endif // MODLOADER_CLIENT_BUILD

--- a/Version_Mod_Loader/hooks/input/keybind_registry.cpp
+++ b/Version_Mod_Loader/hooks/input/keybind_registry.cpp
@@ -5,6 +5,8 @@
 #include <windows.h>
 #include <mutex>
 #include <map>
+#include <unordered_map>
+#include <string>
 #include <vector>
 #include <algorithm>
 #include <cstring>
@@ -187,6 +189,9 @@ namespace Hooks::Input
 	static std::vector<CallbackEntry>      s_callbacks;
 	static std::vector<NamedComboEntry>    s_namedCombos;
 	static std::vector<ComboCallbackEntry> s_comboCallbacks;
+	// Blocking map: canonical combo string (e.g. "Ctrl+C") -> blocking enabled.
+	// Protected by s_mutex. Default absent = non-blocking.
+	static std::unordered_map<std::string, bool> s_blockingMap;
 	static std::mutex s_mutex;
 	static bool s_initialized = false;
 
@@ -207,6 +212,7 @@ namespace Hooks::Input
 		s_callbacks.clear();
 		s_namedCombos.clear();
 		s_comboCallbacks.clear();
+		s_blockingMap.clear();
 		s_initialized = false;
 		ModLoaderLogger::LogInfo(L"[KeybindRegistry] Shutdown - all keybinds cleared");
 	}
@@ -532,6 +538,40 @@ namespace Hooks::Input
 			                                e.event == event && e.callback == callback;
 		                         });
 		s_comboCallbacks.erase(it, s_comboCallbacks.end());
+	}
+
+	// -----------------------------------------------------------------------
+	// Blocking map
+	// -----------------------------------------------------------------------
+	void SetComboBlocking(const char* comboStr, bool blocking)
+	{
+		if (!comboStr || !*comboStr) return;
+
+		// Normalise to a canonical string by round-tripping through Parse/Format.
+		EModKeyModifiers mods = EModKeyMod_None;
+		EModKey key = ParseComboString(comboStr, mods);
+		if (key == EModKey::Unknown) return;
+
+		char canonical[64];
+		FormatComboString(key, mods, canonical, sizeof(canonical));
+
+		std::lock_guard<std::mutex> lock(s_mutex);
+		if (blocking)
+			s_blockingMap[canonical] = true;
+		else
+			s_blockingMap.erase(canonical);
+	}
+
+	bool ShouldBlock(EModKey key, EModKeyModifiers mods)
+	{
+		if (key == EModKey::Unknown) return false;
+
+		char canonical[64];
+		FormatComboString(key, mods, canonical, sizeof(canonical));
+
+		std::lock_guard<std::mutex> lock(s_mutex);
+		auto it = s_blockingMap.find(canonical);
+		return (it != s_blockingMap.end()) && it->second;
 	}
 
 	// -----------------------------------------------------------------------

--- a/Version_Mod_Loader/hooks/input/keybind_registry.cpp
+++ b/Version_Mod_Loader/hooks/input/keybind_registry.cpp
@@ -162,7 +162,31 @@ namespace Hooks::Input
 		PluginKeybindCallback callback;
 	};
 
-	static std::vector<CallbackEntry> s_callbacks;
+	// Named-combo entries: registered via RegisterKeybindByName("Ctrl+F5", ...).
+	// Stores the original combo string so UpdateKeybindByName can find and
+	// update registrations in-place when the user rebinds in the config UI.
+	struct NamedComboEntry
+	{
+		EModKey          key;
+		EModKeyModifiers mods;
+		EModKeyEvent     event;
+		PluginKeybindCallback callback;
+		char comboStr[64];  // original combo string, e.g. "Ctrl+F5" or "F5"
+	};
+
+	// Advanced-combo entries: registered via RegisterKeybindCombo (enum + explicit mods).
+	// Uses PluginKeybindComboCallback — mods are passed back to the caller.
+	struct ComboCallbackEntry
+	{
+		EModKey          key;
+		EModKeyModifiers mods;
+		EModKeyEvent     event;
+		PluginKeybindComboCallback callback;
+	};
+
+	static std::vector<CallbackEntry>      s_callbacks;
+	static std::vector<NamedComboEntry>    s_namedCombos;
+	static std::vector<ComboCallbackEntry> s_comboCallbacks;
 	static std::mutex s_mutex;
 	static bool s_initialized = false;
 
@@ -181,6 +205,8 @@ namespace Hooks::Input
 	{
 		std::lock_guard<std::mutex> lock(s_mutex);
 		s_callbacks.clear();
+		s_namedCombos.clear();
+		s_comboCallbacks.clear();
 		s_initialized = false;
 		ModLoaderLogger::LogInfo(L"[KeybindRegistry] Shutdown - all keybinds cleared");
 	}
@@ -241,6 +267,80 @@ namespace Hooks::Input
 	}
 
 	// -----------------------------------------------------------------------
+	// Combo string helpers (must precede registration functions that call them)
+	// -----------------------------------------------------------------------
+
+	// Parse "Ctrl+Shift+F5" into mods + base key.
+	// Returns EModKey::Unknown on parse failure.
+	static EModKey ParseComboString(const char* combo, EModKeyModifiers& outMods)
+	{
+		outMods = EModKeyMod_None;
+		if (!combo || !*combo)
+			return EModKey::Unknown;
+
+		char buf[128];
+		strncpy_s(buf, combo, _TRUNCATE);
+
+		EModKey baseKey = EModKey::Unknown;
+		char* ctx = nullptr;
+		char* token = strtok_s(buf, "+", &ctx);
+		while (token)
+		{
+			while (*token == ' ') ++token;
+			size_t len = strlen(token);
+			while (len > 0 && token[len - 1] == ' ') token[--len] = '\0';
+
+			auto ieq = [](const char* a, const char* b) -> bool
+			{
+				while (*a && *b)
+				{
+					if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+						return false;
+					++a; ++b;
+				}
+				return *a == '\0' && *b == '\0';
+			};
+
+			if (ieq(token, "ctrl") || ieq(token, "control"))
+				outMods = static_cast<EModKeyModifiers>(outMods | EModKeyMod_Ctrl);
+			else if (ieq(token, "shift"))
+				outMods = static_cast<EModKeyModifiers>(outMods | EModKeyMod_Shift);
+			else if (ieq(token, "alt"))
+				outMods = static_cast<EModKeyModifiers>(outMods | EModKeyMod_Alt);
+			else
+			{
+				EModKey k = NameToModKey(token);
+				if (k != EModKey::Unknown)
+					baseKey = k;
+			}
+			token = strtok_s(nullptr, "+", &ctx);
+		}
+		return baseKey;
+	}
+
+	const char* FormatComboString(EModKey key, EModKeyModifiers mods, char* outBuf, size_t outLen)
+	{
+		const char* keyName = ModKeyToName(key);
+		if (!keyName) keyName = "Unknown";
+
+		if (mods == EModKeyMod_None)
+		{
+			strncpy_s(outBuf, outLen, keyName, _TRUNCATE);
+			return outBuf;
+		}
+
+		char tmp[128] = {};
+		if (mods & EModKeyMod_Ctrl)  { if (tmp[0]) strncat_s(tmp, "+", _TRUNCATE); strncat_s(tmp, "Ctrl",  _TRUNCATE); }
+		if (mods & EModKeyMod_Shift) { if (tmp[0]) strncat_s(tmp, "+", _TRUNCATE); strncat_s(tmp, "Shift", _TRUNCATE); }
+		if (mods & EModKeyMod_Alt)   { if (tmp[0]) strncat_s(tmp, "+", _TRUNCATE); strncat_s(tmp, "Alt",   _TRUNCATE); }
+		strncat_s(tmp, "+", _TRUNCATE);
+		strncat_s(tmp, keyName, _TRUNCATE);
+
+		strncpy_s(outBuf, outLen, tmp, _TRUNCATE);
+		return outBuf;
+	}
+
+	// -----------------------------------------------------------------------
 	// Registration
 	// -----------------------------------------------------------------------
 	void RegisterKeybind(EModKey key, EModKeyEvent event, PluginKeybindCallback callback)
@@ -287,30 +387,151 @@ namespace Hooks::Input
 		s_callbacks.erase(it, s_callbacks.end());
 	}
 
-	void RegisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback)
+	void RegisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback)
 	{
-		if (!keyName || !*keyName)
+		if (!combo || !*combo)
 		{
-			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindByName: null/empty name ignored");
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindByName: null/empty string ignored");
+			return;
+		}
+		if (!callback)
+		{
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindByName: null callback ignored");
 			return;
 		}
 
-		EModKey key = NameToModKey(keyName);
+		EModKeyModifiers mods = EModKeyMod_None;
+		EModKey key = ParseComboString(combo, mods);
 		if (key == EModKey::Unknown)
 		{
-			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindByName: unknown key name '%S'", keyName);
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindByName: could not parse '%S'", combo);
 			return;
 		}
 
-		RegisterKeybind(key, event, callback);
+		// All by-name registrations go into s_namedCombos so UpdateKeybindByName
+		// can always locate and patch them when the user rebinds via the config UI.
+		std::lock_guard<std::mutex> lock(s_mutex);
+		for (auto& e : s_namedCombos)
+		{
+			if (e.key == key && e.mods == mods && e.event == event && e.callback == callback)
+				return; // duplicate
+		}
+
+		NamedComboEntry entry = {};
+		entry.key      = key;
+		entry.mods     = mods;
+		entry.event    = event;
+		entry.callback = callback;
+		strncpy_s(entry.comboStr, combo, _TRUNCATE);
+		s_namedCombos.push_back(entry);
+
+		ModLoaderLogger::LogDebug(L"[KeybindRegistry] Registered named bind: combo=%S event=%u (total=%zu)",
+		                          combo, static_cast<unsigned>(event), s_namedCombos.size());
 	}
 
-	void UnregisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback)
+	void UnregisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback)
 	{
-		if (!keyName || !*keyName || !callback) return;
-		EModKey key = NameToModKey(keyName);
-		if (key != EModKey::Unknown)
-			UnregisterKeybind(key, event, callback);
+		if (!combo || !*combo || !callback) return;
+
+		EModKeyModifiers mods = EModKeyMod_None;
+		EModKey key = ParseComboString(combo, mods);
+		if (key == EModKey::Unknown) return;
+
+		std::lock_guard<std::mutex> lock(s_mutex);
+		auto it = std::remove_if(s_namedCombos.begin(), s_namedCombos.end(),
+		                         [&](const NamedComboEntry& e)
+		                         {
+			                         return e.key == key && e.mods == mods &&
+			                                e.event == event && e.callback == callback;
+		                         });
+		s_namedCombos.erase(it, s_namedCombos.end());
+	}
+
+	void UpdateKeybindByName(const char* pluginName, const char* oldCombo, const char* newCombo)
+	{
+		if (!oldCombo || !newCombo || !*newCombo) return;
+
+		EModKeyModifiers newMods = EModKeyMod_None;
+		EModKey newKey = ParseComboString(newCombo, newMods);
+		if (newKey == EModKey::Unknown)
+		{
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] UpdateKeybindByName: could not parse new combo '%S'", newCombo);
+			return;
+		}
+
+		std::lock_guard<std::mutex> lock(s_mutex);
+		int updated = 0;
+		for (auto& e : s_namedCombos)
+		{
+			if (strcmp(e.comboStr, oldCombo) != 0) continue;
+
+			e.key  = newKey;
+			e.mods = newMods;
+			strncpy_s(e.comboStr, newCombo, _TRUNCATE);
+			++updated;
+		}
+
+		if (updated > 0)
+			ModLoaderLogger::LogDebug(L"[KeybindRegistry] Live-rebound %d registration(s) for plugin=%S: %S -> %S",
+			                          updated, pluginName ? pluginName : "?", oldCombo, newCombo);
+	}
+
+	// -----------------------------------------------------------------------
+	// Modifier sampling
+	// -----------------------------------------------------------------------
+	EModKeyModifiers SampleCurrentModifiers()
+	{
+		EModKeyModifiers mods = EModKeyMod_None;
+		if ((GetAsyncKeyState(VK_LCONTROL) | GetAsyncKeyState(VK_RCONTROL)) & 0x8000)
+			mods = static_cast<EModKeyModifiers>(mods | EModKeyMod_Ctrl);
+		if ((GetAsyncKeyState(VK_LSHIFT) | GetAsyncKeyState(VK_RSHIFT)) & 0x8000)
+			mods = static_cast<EModKeyModifiers>(mods | EModKeyMod_Shift);
+		if ((GetAsyncKeyState(VK_LMENU) | GetAsyncKeyState(VK_RMENU)) & 0x8000)
+			mods = static_cast<EModKeyModifiers>(mods | EModKeyMod_Alt);
+		return mods;
+	}
+
+	// -----------------------------------------------------------------------
+	// Combo registration (v28)
+	// -----------------------------------------------------------------------
+	void RegisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback)
+	{
+		if (!callback)
+		{
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindCombo: null callback ignored");
+			return;
+		}
+		if (key == EModKey::Unknown)
+		{
+			ModLoaderLogger::LogWarn(L"[KeybindRegistry] RegisterKeybindCombo: EModKey::Unknown ignored");
+			return;
+		}
+
+		std::lock_guard<std::mutex> lock(s_mutex);
+		for (auto& e : s_comboCallbacks)
+		{
+			if (e.key == key && e.mods == mods && e.event == event && e.callback == callback)
+				return;
+		}
+		s_comboCallbacks.push_back({key, mods, event, callback});
+
+		char combo[64];
+		FormatComboString(key, mods, combo, sizeof(combo));
+		ModLoaderLogger::LogDebug(L"[KeybindRegistry] Registered combo: %S event=%u (total=%zu)",
+		                          combo, static_cast<unsigned>(event), s_comboCallbacks.size());
+	}
+
+	void UnregisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback)
+	{
+		if (!callback) return;
+		std::lock_guard<std::mutex> lock(s_mutex);
+		auto it = std::remove_if(s_comboCallbacks.begin(), s_comboCallbacks.end(),
+		                         [&](const ComboCallbackEntry& e)
+		                         {
+			                         return e.key == key && e.mods == mods &&
+			                                e.event == event && e.callback == callback;
+		                         });
+		s_comboCallbacks.erase(it, s_comboCallbacks.end());
 	}
 
 	// -----------------------------------------------------------------------
@@ -342,31 +563,65 @@ namespace Hooks::Input
 	}
 
 	// -----------------------------------------------------------------------
+	// DispatchCombo — fires combo callbacks whose (key, mods, event) match
+	// -----------------------------------------------------------------------
+	void DispatchCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event)
+	{
+		// Snapshot both named-combo and advanced-combo lists under lock.
+		std::vector<PluginKeybindCallback>      namedToCall;
+		std::vector<PluginKeybindComboCallback> advToCall;
+		{
+			std::lock_guard<std::mutex> lock(s_mutex);
+			for (auto& e : s_namedCombos)
+			{
+				if (e.key != key || e.event != event) continue;
+				// Named entries with no mods fire regardless of current modifier state
+				// (same behaviour as the old plain RegisterKeybind path).
+				// Named entries with mods require an exact match.
+				if (e.mods == EModKeyMod_None || e.mods == mods)
+					namedToCall.push_back(e.callback);
+			}
+			for (auto& e : s_comboCallbacks)
+			{
+				if (e.key == key && e.mods == mods && e.event == event)
+					advToCall.push_back(e.callback);
+			}
+		}
+
+		for (auto cb : namedToCall)
+		{
+			if (cb) try { cb(key, event); } catch (...) {}
+		}
+		for (auto cb : advToCall)
+		{
+			if (cb) try { cb(key, mods, event); } catch (...) {}
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// GetActiveKeys — returns (EModKey, VK) pairs with at least one callback
+	// (simple or combo).
 	// -----------------------------------------------------------------------
 	std::vector<std::pair<EModKey, int>> GetActiveKeys()
 	{
 		std::vector<std::pair<EModKey, int>> result;
 
+		auto addIfNew = [&](EModKey k)
+		{
+			for (auto& r : result)
+				if (r.first == k) return;
+			int vk = ModKeyToVK(k);
+			if (vk != 0)
+				result.push_back({k, vk});
+		};
+
 		std::lock_guard<std::mutex> lock(s_mutex);
 		for (auto& e : s_callbacks)
-		{
-			// Add if not already in result
-			bool found = false;
-			for (auto& r : result)
-				if (r.first == e.key)
-				{
-					found = true;
-					break;
-				}
-
-			if (!found)
-			{
-				int vk = ModKeyToVK(e.key);
-				if (vk != 0)
-					result.push_back({e.key, vk});
-			}
-		}
+			addIfNew(e.key);
+		for (auto& e : s_namedCombos)
+			addIfNew(e.key);
+		for (auto& e : s_comboCallbacks)
+			addIfNew(e.key);
 
 		return result;
 	}

--- a/Version_Mod_Loader/hooks/input/keybind_registry.h
+++ b/Version_Mod_Loader/hooks/input/keybind_registry.h
@@ -61,6 +61,18 @@ namespace Hooks::Input
 	// mods == EModKeyMod_None produces just the key name.
 	const char* FormatComboString(EModKey key, EModKeyModifiers mods, char* outBuf, size_t outLen);
 
+	// --- Blocking ---
+	// Mark a canonical combo string (e.g. "Ctrl+C", "F5") as blocking or non-blocking.
+	// When blocking is true, the InputKey detour returns false for that combo,
+	// preventing UE5 from processing the key. Stored per-combo in a runtime map;
+	// persisted to the plugin INI by the config UI.
+	void SetComboBlocking(const char* comboStr, bool blocking);
+
+	// Returns true if the given (key, mods) combination is currently set to blocking.
+	// Uses FormatComboString to produce the canonical key and looks it up in the map.
+	// Returns false (non-blocking) by default when no entry exists.
+	bool ShouldBlock(EModKey key, EModKeyModifiers mods);
+
 	// --- Dispatch ---
 	// Fires simple callbacks (mod-unaware).
 	void Dispatch(EModKey key, EModKeyEvent event);

--- a/Version_Mod_Loader/hooks/input/keybind_registry.h
+++ b/Version_Mod_Loader/hooks/input/keybind_registry.h
@@ -24,9 +24,21 @@ namespace Hooks::Input
 	void RegisterKeybind(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
 	void UnregisterKeybind(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
 
-	// --- Callback registration (by UE key name string) ---
-	void RegisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
-	void UnregisterKeybindByName(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
+	// --- Callback registration (by name string, plain or combo) ---
+	// Accepts "F5" or combo strings like "Ctrl+C", "Shift+F5", "Ctrl+Shift+Delete".
+	// Routes to plain or combo storage automatically; callback signature is the same either way.
+	void RegisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback);
+	void UnregisterKeybindByName(const char* combo, EModKeyEvent event, PluginKeybindCallback callback);
+
+	// Called by the config UI when a Keybind config entry changes value.
+	// Finds all by-name registrations for pluginName whose stored combo matches
+	// oldCombo and re-registers them with newCombo in-place.
+	void UpdateKeybindByName(const char* pluginName, const char* oldCombo, const char* newCombo);
+
+	// --- Advanced combo registration (v28) ---
+	// Register by enum + modifier mask; callback receives the mods at fire time.
+	void RegisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback);
+	void UnregisterKeybindCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback);
 
 	// --- Lookup helpers ---
 
@@ -42,11 +54,20 @@ namespace Hooks::Input
 	// Returns the EModKey for a UE key name string (case-insensitive), or EModKey::Unknown.
 	EModKey NameToModKey(const char* name);
 
-	// --- Dispatch ---
-	// Called by the input processor each frame to fire registered callbacks.
-	void Dispatch(EModKey key, EModKeyEvent event);
+	// Returns the current modifier bitmask by sampling GetAsyncKeyState.
+	EModKeyModifiers SampleCurrentModifiers();
 
-	// Returns the set of (EModKey, VK) pairs that have at least one registered callback.
-	// Used by the input processor to know which keys to poll.
+	// Formats a combo string into outBuf (e.g. "Ctrl+F5"). Returns outBuf.
+	// mods == EModKeyMod_None produces just the key name.
+	const char* FormatComboString(EModKey key, EModKeyModifiers mods, char* outBuf, size_t outLen);
+
+	// --- Dispatch ---
+	// Fires simple callbacks (mod-unaware).
+	void Dispatch(EModKey key, EModKeyEvent event);
+	// Fires named-combo and advanced-combo callbacks for the given key + current mods.
+	void DispatchCombo(EModKey key, EModKeyModifiers mods, EModKeyEvent event);
+
+	// Returns the set of (EModKey, VK) pairs that have at least one registered callback
+	// (simple or combo).  Used by the input processor to know which keys to poll.
 	std::vector<std::pair<EModKey, int>> GetActiveKeys();
 }

--- a/Version_Mod_Loader/plugins/plugin_interface.h
+++ b/Version_Mod_Loader/plugins/plugin_interface.h
@@ -23,11 +23,11 @@
 //      Added PluginWindowHints struct and windowHints field to PluginWidgetDesc.
 //      MIN remains 23.
 #define PLUGIN_INTERFACE_VERSION_MIN 26
-#define PLUGIN_INTERFACE_VERSION_MAX 26
+#define PLUGIN_INTERFACE_VERSION_MAX 30
 #define PLUGIN_INTERFACE_VERSION PLUGIN_INTERFACE_VERSION_MAX
 
 enum class PluginLogLevel { Trace = 0, Debug = 1, Info = 2, Warn = 3, Error = 4 };
-enum class ConfigValueType { String, Integer, Float, Boolean };
+enum class ConfigValueType { String, Integer, Float, Boolean, Keybind };
 
 struct ConfigEntry
 {
@@ -213,14 +213,43 @@ enum class EModKey : uint32_t
 
 enum class EModKeyEvent : uint32_t { Pressed = 0, Released = 1 };
 
+// Modifier bitmask used with combo keybinds (v28).
+// Each flag covers both Left and Right variants of that modifier key.
+enum EModKeyModifiers : uint32_t
+{
+	EModKeyMod_None  = 0,
+	EModKeyMod_Ctrl  = 1 << 0,
+	EModKeyMod_Shift = 1 << 1,
+	EModKeyMod_Alt   = 1 << 2,
+};
+
 typedef void (*PluginKeybindCallback)(EModKey key, EModKeyEvent event);
+
+// Combo callback — receives the base key, the modifier bitmask held at the
+// moment of the transition, and the event type (v28).
+typedef void (*PluginKeybindComboCallback)(EModKey key, EModKeyModifiers mods, EModKeyEvent event);
 
 struct IPluginInputEvents
 {
+	// v15 — register by enum; fires on key transition regardless of modifier state.
 	void (*RegisterKeybind)(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
 	void (*UnregisterKeybind)(EModKey key, EModKeyEvent event, PluginKeybindCallback callback);
-	void (*RegisterKeybindByName)(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
-	void (*UnregisterKeybindByName)(const char* keyName, EModKeyEvent event, PluginKeybindCallback callback);
+
+	// v15/v30 — register by name string.  Accepts plain key names ("F5") and
+	// combo strings ("Ctrl+C", "Shift+F5", "Ctrl+Shift+Delete").  Modifier tokens
+	// are case-insensitive.  The callback receives the base key and event; the
+	// modifiers are implicit in the name you registered.
+	// The modloader tracks these registrations and automatically re-registers
+	// the keybind when the user rebinds it in the plugin config UI.
+	void (*RegisterKeybindByName)(const char* combo, EModKeyEvent event, PluginKeybindCallback callback);
+	void (*UnregisterKeybindByName)(const char* combo, EModKeyEvent event, PluginKeybindCallback callback);
+
+	// v28 — advanced: register by enum + explicit modifier mask.  Fires only when
+	// the key transitions with exactly those modifiers held.  The callback receives
+	// the modifier mask at fire time.  Use this only when you need the mods passed
+	// back; most plugins should use RegisterKeybindByName instead.
+	void (*RegisterKeybindCombo)(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback);
+	void (*UnregisterKeybindCombo)(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback);
 };
 
 // ---------------------------------------------------------------------------

--- a/Version_Mod_Loader/plugins/plugin_manager.cpp
+++ b/Version_Mod_Loader/plugins/plugin_manager.cpp
@@ -20,6 +20,59 @@
 
 namespace PluginManager
 {
+	// SEH helpers for catching crashes inside plugin-supplied functions.
+	// Must be plain POD functions with no C++ objects (C2712).
+	struct PluginCrashCtx { DWORD code; uintptr_t addr; };
+	static PluginCrashCtx g_lastPluginCrash;
+
+	static LONG PluginCrashFilter(EXCEPTION_POINTERS* ep)
+	{
+		g_lastPluginCrash.code = ep->ExceptionRecord->ExceptionCode;
+		g_lastPluginCrash.addr = reinterpret_cast<uintptr_t>(ep->ExceptionRecord->ExceptionAddress);
+		return EXCEPTION_EXECUTE_HANDLER;
+	}
+
+	// Logs a caught crash, showing the fault RVA relative to the plugin's own DLL so the
+	// plugin author can locate the crash in their own binary (e.g. with a map file or PDB).
+	static void LogPluginCrash(const char* pluginName, HMODULE hModule, const wchar_t* context)
+	{
+		uintptr_t base   = reinterpret_cast<uintptr_t>(hModule);
+		uintptr_t offset = (base && g_lastPluginCrash.addr >= base) ? g_lastPluginCrash.addr - base : 0;
+		ModLoaderLogger::LogError(
+			L"[PluginManager] Plugin '%S' CRASHED during %s -- code=0x%08X  fault=0x%llX  (+0x%llX from plugin DLL base)",
+			pluginName, context,
+			g_lastPluginCrash.code,
+			static_cast<unsigned long long>(g_lastPluginCrash.addr),
+			static_cast<unsigned long long>(offset));
+	}
+
+	static bool CallShutdownSEH(PluginShutdownFunc fn)
+	{
+		g_lastPluginCrash = {};
+		__try { fn(); return true; }
+		__except (PluginCrashFilter(GetExceptionInformation())) { return false; }
+	}
+
+	struct InitSEHResult { bool crashed; bool retval; };
+	static InitSEHResult CallInitSEH(PluginInitFunc fn, IPluginSelf* self)
+	{
+		InitSEHResult r = {};
+		g_lastPluginCrash = {};
+		__try { r.retval = fn(self) != 0; }
+		__except (PluginCrashFilter(GetExceptionInformation())) { r.crashed = true; }
+		return r;
+	}
+
+	static PluginInfo* CallGetInfoSEH(GetPluginInfoFunc fn)
+	{
+		PluginInfo* result = nullptr;
+		g_lastPluginCrash = {};
+		__try { result = fn(); }
+		__except (PluginCrashFilter(GetExceptionInformation())) {}
+		return result;
+	}
+
+
 	// Structure to hold loaded plugin information
 	struct LoadedPlugin
 	{
@@ -87,10 +140,23 @@ namespace PluginManager
 			return false;
 		}
 
-		PluginInfo* info = getInfo();
+		PluginInfo* info = CallGetInfoSEH(getInfo);
 		if (!info)
 		{
-			ModLoaderLogger::LogMessage(L"Plugin GetPluginInfo returned nullptr: %s", rec.fileName.c_str());
+			if (g_lastPluginCrash.code)
+			{
+				uintptr_t base   = reinterpret_cast<uintptr_t>(hModule);
+				uintptr_t offset = (base && g_lastPluginCrash.addr >= base) ? g_lastPluginCrash.addr - base : 0;
+				ModLoaderLogger::LogError(
+					L"[PluginManager] Plugin '%s' CRASHED in GetPluginInfo -- code=0x%08X  fault=0x%llX  (+0x%llX from plugin DLL base)",
+					rec.fileName.c_str(), g_lastPluginCrash.code,
+					static_cast<unsigned long long>(g_lastPluginCrash.addr),
+					static_cast<unsigned long long>(offset));
+			}
+			else
+			{
+				ModLoaderLogger::LogMessage(L"Plugin GetPluginInfo returned nullptr: %s", rec.fileName.c_str());
+			}
 			FreeLibrary(hModule);
 			return false;
 		}
@@ -262,6 +328,49 @@ namespace PluginManager
 		ModLoaderLogger::LogMessage(L"Loaded %d plugin DLL(s) from Plugins (PluginInit deferred)", loadedCount);
 	}
 
+	// Calls PluginInit on a single record that has been loaded but not yet initialized.
+	// Caller must hold g_pluginLock. Returns true if the plugin is now initialized.
+	static bool InitPluginRecord(LoadedPlugin& plugin)
+	{
+		ModLoaderLogger::LogMessage(L"Calling PluginInit for: %S v%S", plugin.cachedName.c_str(), plugin.cachedVersion.c_str());
+
+		plugin.self.logger  = ModLoaderLogger::GetPluginLogger();
+		plugin.self.config  = ModLoaderLogger::GetPluginConfig();
+		plugin.self.scanner = ModLoaderLogger::GetPluginScanner();
+		plugin.self.hooks   = ModLoaderLogger::GetPluginHooks();
+
+#ifdef MODLOADER_CLIENT_BUILD
+		UI::PluginPanelRegistry::SetCurrentRegistrationPlugin(plugin.cachedName.c_str());
+#endif
+
+		InitSEHResult initResult = CallInitSEH(plugin.init, &plugin.self);
+		bool success = false;
+
+		if (initResult.crashed)
+		{
+			LogPluginCrash(plugin.cachedName.c_str(), plugin.hModule, L"PluginInit");
+			ModLoaderLogger::LogError(L"Plugin '%S' crashed during PluginInit -- it has been left unloaded", plugin.cachedName.c_str());
+		}
+		else if (initResult.retval)
+		{
+			plugin.isInitialized = true;
+			success = true;
+			ModLoaderLogger::LogMessage(L"Plugin initialized: %S", plugin.cachedName.c_str());
+#ifdef MODLOADER_CLIENT_BUILD
+			UI::ModLoaderWindow::LoadBlockingStateForPlugin(plugin.cachedName.c_str());
+#endif
+		}
+		else
+		{
+			ModLoaderLogger::LogMessage(L"Plugin initialization failed: %S", plugin.cachedName.c_str());
+		}
+
+#ifdef MODLOADER_CLIENT_BUILD
+		UI::PluginPanelRegistry::SetCurrentRegistrationPlugin(nullptr);
+#endif
+		return success;
+	}
+
 	void InitAllLoadedPlugins()
 	{
 		if (!g_managerInitialized)
@@ -287,7 +396,6 @@ namespace PluginManager
 				continue;
 
 			current++;
-			ModLoaderLogger::LogMessage(L"Calling PluginInit for: %S v%S", plugin->cachedName.c_str(), plugin->cachedVersion.c_str());
 
 #ifdef MODLOADER_CLIENT_BUILD
 			{
@@ -298,32 +406,10 @@ namespace PluginManager
 			}
 #endif
 
-			plugin->self.logger  = ModLoaderLogger::GetPluginLogger();
-			plugin->self.config  = ModLoaderLogger::GetPluginConfig();
-			plugin->self.scanner = ModLoaderLogger::GetPluginScanner();
-			plugin->self.hooks   = ModLoaderLogger::GetPluginHooks();
-
-#ifdef MODLOADER_CLIENT_BUILD
-			UI::PluginPanelRegistry::SetCurrentRegistrationPlugin(plugin->cachedName.c_str());
-#endif
-			if (plugin->init(&plugin->self))
-			{
-				plugin->isInitialized = true;
+			if (InitPluginRecord(*plugin))
 				initCount++;
-				ModLoaderLogger::LogMessage(L"Plugin initialized: %S", plugin->cachedName.c_str());
-#ifdef MODLOADER_CLIENT_BUILD
-				// Load blocking state so input suppression is active before any key press.
-				UI::ModLoaderWindow::LoadBlockingStateForPlugin(plugin->cachedName.c_str());
-#endif
-			}
 			else
-			{
 				failCount++;
-				ModLoaderLogger::LogMessage(L"Plugin initialization failed: %S", plugin->cachedName.c_str());
-			}
-#ifdef MODLOADER_CLIENT_BUILD
-			UI::PluginPanelRegistry::SetCurrentRegistrationPlugin(nullptr);
-#endif
 		}
 
 		LeaveCriticalSection(&g_pluginLock);
@@ -347,7 +433,8 @@ namespace PluginManager
 			if (plugin->isInitialized)
 			{
 				ModLoaderLogger::LogMessage(L"Shutting down plugin: %S", plugin->cachedName.c_str());
-				plugin->shutdown();
+				if (!CallShutdownSEH(plugin->shutdown))
+					LogPluginCrash(plugin->cachedName.c_str(), plugin->hModule, L"PluginShutdown (unload all)");
 				plugin->isInitialized = false;
 			}
 
@@ -425,7 +512,8 @@ namespace PluginManager
 
 		LoadedPlugin& p = *g_loadedPlugins[index];
 		ModLoaderLogger::LogMessage(L"Unloading plugin: %S", p.cachedName.c_str());
-		p.shutdown();
+		if (!CallShutdownSEH(p.shutdown))
+			LogPluginCrash(p.cachedName.c_str(), p.hModule, L"PluginShutdown (unload)");
 		p.isInitialized = false;
 		FreeLibrary(p.hModule);
 		p.hModule = nullptr;
@@ -451,7 +539,8 @@ namespace PluginManager
 
 		if (p.isInitialized)
 		{
-			p.shutdown();
+			if (!CallShutdownSEH(p.shutdown))
+				LogPluginCrash(p.cachedName.c_str(), p.hModule, L"PluginShutdown (reload)");
 			p.isInitialized = false;
 		}
 		if (p.hModule)
@@ -463,16 +552,19 @@ namespace PluginManager
 
 		bool ok = LoadPluginIntoRecord(p);
 
-		LeaveCriticalSection(&g_pluginLock);
-
 		if (ok)
 		{
 			RefreshSelfPointers(p);
-			InitAllLoadedPlugins();
-			ModLoaderLogger::LogMessage(L"Plugin reloaded and initialized: %S", p.cachedName.c_str());
+			bool inited = InitPluginRecord(p);
+			LeaveCriticalSection(&g_pluginLock);
+			if (inited)
+				ModLoaderLogger::LogMessage(L"Plugin reloaded and initialized: %S", p.cachedName.c_str());
+			else
+				ModLoaderLogger::LogMessage(L"Plugin reloaded but PluginInit failed: %S", p.cachedName.c_str());
 		}
 		else
 		{
+			LeaveCriticalSection(&g_pluginLock);
 			ModLoaderLogger::LogMessage(L"Plugin reload failed for index %d", index);
 		}
 

--- a/Version_Mod_Loader/plugins/plugin_manager.cpp
+++ b/Version_Mod_Loader/plugins/plugin_manager.cpp
@@ -14,6 +14,7 @@
 
 #ifdef MODLOADER_CLIENT_BUILD
 #include "UI/splash_window.h"
+#include "UI/modloader_window.h"
 #include "UI/plugin_panel_registry.h"
 #endif
 
@@ -310,6 +311,10 @@ namespace PluginManager
 				plugin->isInitialized = true;
 				initCount++;
 				ModLoaderLogger::LogMessage(L"Plugin initialized: %S", plugin->cachedName.c_str());
+#ifdef MODLOADER_CLIENT_BUILD
+				// Load blocking state so input suppression is active before any key press.
+				UI::ModLoaderWindow::LoadBlockingStateForPlugin(plugin->cachedName.c_str());
+#endif
 			}
 			else
 			{


### PR DESCRIPTION
- Plugins are now correctly unloaded/reloaded, which should fix a lot of crashes during this
- Plugins that crash during a reload will now log a offset, which plugin authors can use via their PDB to find the line that caused the issue
- Config F2 menu is now a bit better laid out
- Added a new Keybind config type, which allows for keybinds to be mapped properly
- Keybinds can be set to `Block`.  Blocking mode keybinds will not allow the game to see these key presses, for example a keybind of CTRL+C wont touch the drone.
- Now using ViewPort for InputKey detour and supression