### PR TITLE
Multiple new features and fixes

### DIFF
--- a/Version_Mod_Loader/UI/imgui_backend.cpp
+++ b/Version_Mod_Loader/UI/imgui_backend.cpp
@@ -245,12 +245,13 @@ static LRESULT CALLBACK HookedWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 	if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
 		return true;
 
-	// Dispatch plugin keybind callbacks and optionally swallow the message.
-	// Only fires when the modloader UI is not open (same gate as InputKey hook).
-	if (!ShouldCaptureInput())
+	// Dispatch plugin keybind callbacks unconditionally so that toggle-style
+	// keybinds (e.g. F2) can close the UI even while it is open.
+	// Only swallow blocking messages when the UI is not capturing input.
 	{
-		if (DispatchKeybindMessage(msg, wParam, lParam))
-			return 0; // blocking -- swallow before UE5 sees it
+		bool blocked = DispatchKeybindMessage(msg, wParam, lParam);
+		if (!ShouldCaptureInput() && blocked)
+			return 0;
 	}
 
 	if (ShouldCaptureInput())

--- a/Version_Mod_Loader/UI/modloader_window.cpp
+++ b/Version_Mod_Loader/UI/modloader_window.cpp
@@ -44,6 +44,7 @@ namespace UI::ModLoaderWindow
     struct RebindState
     {
         bool active           = false;
+        bool pendingOpen      = false; // set inside a table; OpenPopup deferred to modal site
         char section[64]      = {};
         char cfgKey[64]       = {};   // the INI key name (not keyboard key)
         char pluginName[64]   = {};
@@ -377,7 +378,7 @@ namespace UI::ModLoaderWindow
                 strncpy_s(s_rebind.pluginName, pluginName, _TRUNCATE);
                 s_rebind.waitingForRelease = true;
                 s_rebind.active            = true;
-                ImGui::OpenPopup("##rebind_modal");
+                s_rebind.pendingOpen       = true; // OpenPopup deferred — called from outside the table
             }
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
         }
@@ -458,6 +459,14 @@ namespace UI::ModLoaderWindow
     {
         if (!s_rebind.active)
             return;
+
+        // OpenPopup must be called at the same ID-stack level as BeginPopupModal.
+        // The button that sets pendingOpen lives inside a BeginTable, so we defer here.
+        if (s_rebind.pendingOpen)
+        {
+            ImGui::OpenPopup("##rebind_modal");
+            s_rebind.pendingOpen = false;
+        }
 
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));

--- a/Version_Mod_Loader/UI/plugin_widget_registry.cpp
+++ b/Version_Mod_Loader/UI/plugin_widget_registry.cpp
@@ -95,6 +95,7 @@ namespace UI::PluginWidgetRegistry
                     ImGui::SetNextWindowSize(ImVec2(hints->width, hints->height), (ImGuiCond)hints->size_cond);
                 if (hints->pos_x >= 0.0f && hints->pos_y >= 0.0f)
                     ImGui::SetNextWindowPos(ImVec2(hints->pos_x, hints->pos_y), (ImGuiCond)hints->pos_cond, ImVec2(hints->pivot_x, hints->pivot_y));
+                flags |= (ImGuiWindowFlags)hints->extra_window_flags;
             }
             else
             {

--- a/Version_Mod_Loader/core/globals.cpp
+++ b/Version_Mod_Loader/core/globals.cpp
@@ -5,3 +5,4 @@ HANDLE g_autoUpdateThread = NULL;
 HANDLE g_pluginsLoadedEvent = NULL;
 HANDLE g_engineReadyEvent = NULL;
 HANDLE g_ue4ssReadyEvent  = NULL;
+HANDLE g_pluginsReadyEvent = NULL;

--- a/Version_Mod_Loader/core/globals.h
+++ b/Version_Mod_Loader/core/globals.h
@@ -7,3 +7,4 @@ extern HANDLE g_autoUpdateThread;
 extern HANDLE g_pluginsLoadedEvent;
 extern HANDLE g_engineReadyEvent;
 extern HANDLE g_ue4ssReadyEvent;
+extern HANDLE g_pluginsReadyEvent;

--- a/Version_Mod_Loader/core/hook_management.cpp
+++ b/Version_Mod_Loader/core/hook_management.cpp
@@ -30,6 +30,7 @@ void InstallAllHooks()
 
     Hooks::EngineInit::SetSyncEvents(g_engineReadyEvent, g_pluginsLoadedEvent);
     Hooks::EngineInit::SetUE4SSReadyEvent(g_ue4ssReadyEvent);
+    Hooks::EngineInit::SetPluginsReadyEvent(g_pluginsReadyEvent);
 
     if (Hooks::EngineInit::Install())
     {
@@ -41,6 +42,8 @@ void InstallAllHooks()
         ModLoaderLogger::LogWarn(L"  WARNING: EngineInit hook failed to install -- loading plugins immediately");
         if (g_engineReadyEvent)
             SetEvent(g_engineReadyEvent);
+        if (g_pluginsReadyEvent)
+            SetEvent(g_pluginsReadyEvent);
     }
 
     Splash::SetStatus(L"Installing EngineShutdown hook...");

--- a/Version_Mod_Loader/core/init_phases.cpp
+++ b/Version_Mod_Loader/core/init_phases.cpp
@@ -30,7 +30,7 @@ void InitSubsystems()
 void InstallHooksPhase()
 {
     Splash::SetStatus(L"Installing core game hooks...");
-    Splash::SetProgress(0.15f);
+    Splash::SetProgress(0.05f);
     InstallAllHooks();
 }
 
@@ -48,12 +48,11 @@ void LoadPluginsPhase()
     Splash::SetProgress(0.85f);
 }
 
-void InitPluginsIfReady()
+void InitPluginsPhase()
 {
-    if (Hooks::GameInstanceInit::HasFired())
-    {
-        ModLoaderLogger::LogInfo(L"[dllmain] GameInstanceInit already fired before plugins loaded -- calling InitAllLoadedPlugins now");
-        PluginManager::InitAllLoadedPlugins();
-    }
+    // Engine init has completed and the main thread is held before we get here,
+    // so it is always safe to call PluginInit now -- no need to wait for GameInstanceInit.
+    ModLoaderLogger::LogInfo(L"[init] Calling PluginInit on all loaded plugins");
+    PluginManager::InitAllLoadedPlugins();
     PluginManager::MarkStartupComplete();
 }

--- a/Version_Mod_Loader/core/init_phases.h
+++ b/Version_Mod_Loader/core/init_phases.h
@@ -6,4 +6,4 @@ void InitSubsystems();
 void InstallHooksPhase();
 void WaitForEnginePhase();
 void LoadPluginsPhase();
-void InitPluginsIfReady();
+void InitPluginsPhase();

--- a/Version_Mod_Loader/core/init_thread.cpp
+++ b/Version_Mod_Loader/core/init_thread.cpp
@@ -11,9 +11,6 @@
 #include "../UI/splash_window.h"
 #include "../hooks/game/world_begin_play/world_begin_play.h"
 #include "../hooks/game/engine_tick/engine_tick.h"
-#include "../plugins/plugin_manager.h"
-#include "../utils/thread_utils.h"
-
 #ifdef MODLOADER_CLIENT_BUILD
 #include "../hooks/input/input_processor.h"
 #endif
@@ -21,6 +18,11 @@
 
 DWORD WINAPI MainInitThreadProc(LPVOID)
 {
+    // ------------------------------------------------------------------
+    // Stage 1: Hook installation
+    // Install all detours before the engine gets far enough to miss them.
+    // The main thread runs freely here -- hook patching requires it.
+    // ------------------------------------------------------------------
     {
         const auto typeResult = GameTypeChecker::Check();
         if (typeResult == GameTypeChecker::Result::SilentBail)
@@ -29,13 +31,15 @@ DWORD WINAPI MainInitThreadProc(LPVOID)
             ExitProcess(1);
     }
 
-#ifdef MODLOADER_CLIENT_BUILD
-    ModLoaderLogger::LogInfo(L"Running client build of modloader");
-#else
-    ModLoaderLogger::LogInfo(L"Running server build of modloader");
-#endif
-
     Splash::Show();
+    InstallHooksPhase();
+    LogToFile::Info("[init] Stage 1 complete -- hooks installed, main thread running");
+
+    // ------------------------------------------------------------------
+    // Stage 2: Subsystem init + wait for engine ready
+    // Hooks are in place; now initialise subsystems and block until the
+    // engine fires the ready signal through one of those hooks.
+    // ------------------------------------------------------------------
     Splash::SetStatus(L"Starting mod loader...");
     Splash::SetProgress(0.0f);
 
@@ -46,23 +50,33 @@ DWORD WINAPI MainInitThreadProc(LPVOID)
     InitSubsystems();
 
 #ifdef MODLOADER_CLIENT_BUILD
+    ModLoaderLogger::LogInfo(L"Running client build of modloader");
     Hooks::Input::InstallInputProcessor();
     Hooks::InputHook::Install();
+#else
+    ModLoaderLogger::LogInfo(L"Running server build of modloader");
 #endif
 
     Hooks::WorldBeginPlay::Install();
     Hooks::EngineTick::Install();
 
-    Splash::SetStatus(L"Checking for updates and installing hooks...");
-    g_autoUpdateThread = CreateThread(nullptr, 0, AutoUpdateThreadProc, nullptr, 0, nullptr);
-    if (!g_autoUpdateThread)
-        LogToFile::Warn("[ModLoader] Failed to create auto-update thread (%lu) -- running synchronously", GetLastError());
+    WaitForEnginePhase();
+    ModLoaderLogger::LogInfo(L"[init] Stage 2 complete -- engine ready");
 
+    // ------------------------------------------------------------------
+    // Stage 3: Plugin loading and initialisation
+    // Run the auto-updater first so plugin DLLs on disk are up to date
+    // before we load them. The main thread is held by the engine init hook
+    // for the duration of this stage.
+    // ------------------------------------------------------------------
+#ifdef MODLOADER_CLIENT_BUILD
+    InitClientUI();
+#endif
+
+    Splash::SetStatus(L"Checking for plugin updates...");
+    g_autoUpdateThread = CreateThread(nullptr, 0, AutoUpdateThreadProc, nullptr, 0, nullptr);
     if (g_autoUpdateThread)
     {
-        InstallHooksPhase();
-        WaitForEnginePhase();
-
         Splash::SetStatus(L"Waiting for update check to complete...");
         WaitForSingleObject(g_autoUpdateThread, INFINITE);
         CloseHandle(g_autoUpdateThread);
@@ -70,37 +84,16 @@ DWORD WINAPI MainInitThreadProc(LPVOID)
     }
     else
     {
-        Splash::SetStatus(L"Checking for plugin updates...");
-        Splash::SetProgress(0.10f);
+        LogToFile::Warn("[ModLoader] Failed to create auto-update thread (%lu) -- running synchronously", GetLastError());
         ModLoaderLogger::RunAutoUpdate();
-        InstallHooksPhase();
-        WaitForEnginePhase();
     }
-
-#ifdef MODLOADER_CLIENT_BUILD
-    InitClientUI();
-#endif
 
     LoadPluginsPhase();
-    InitPluginsIfReady();
+    InitPluginsPhase();
 
-    {
-        HANDLE hEvent = PluginManager::GetPluginsInitializedEvent();
-        if (hEvent && WaitForSingleObject(hEvent, 0) != WAIT_OBJECT_0)
-        {
-            Splash::SetStatus(L"Waiting for game engine...");
-            while (WaitForSingleObject(hEvent, 0) != WAIT_OBJECT_0)
-            {
-                MSG msg;
-                while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-                {
-                    TranslateMessage(&msg);
-                    DispatchMessageW(&msg);
-                }
-                MsgWaitForMultipleObjects(1, &hEvent, FALSE, 50, QS_ALLINPUT);
-            }
-        }
-    }
+    ModLoaderLogger::LogInfo(L"[init] Stage 3 complete -- plugins initialised, releasing main thread");
+    if (g_pluginsReadyEvent)
+        SetEvent(g_pluginsReadyEvent);
 
     Splash::SetStatus(L"Ready.");
     Splash::SetProgress(1.0f);

--- a/Version_Mod_Loader/dllmain.cpp
+++ b/Version_Mod_Loader/dllmain.cpp
@@ -59,6 +59,18 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
             LogToFile::Warn("Failed to create UE4SS-ready event (%lu) -- UE4SS load will use timeout fallback", GetLastError());
         }
 
+        g_pluginsReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!g_pluginsReadyEvent)
+        {
+            LogToFile::Error("FATAL: Failed to create plugins-ready event (%lu)", GetLastError());
+            CloseHandle(g_pluginsLoadedEvent); g_pluginsLoadedEvent = NULL;
+            CloseHandle(g_engineReadyEvent);   g_engineReadyEvent   = NULL;
+            if (g_ue4ssReadyEvent) { CloseHandle(g_ue4ssReadyEvent); g_ue4ssReadyEvent = NULL; }
+            DwmapiProxy::Shutdown();
+            LogToFile::Shutdown();
+            return FALSE;
+        }
+
         if (GetCurrentThreadId() == get_main_thread_id())
         {
             LogToFile::Info("DllMain on main thread -- deferring init via QueueUserAPC");

--- a/Version_Mod_Loader/hooks/game/engine_init/engine_init.cpp
+++ b/Version_Mod_Loader/hooks/game/engine_init/engine_init.cpp
@@ -1,6 +1,7 @@
 ﻿#include "pch.h"
 #include "engine_init.h"
 #include "logging/logger.h"
+#include "logging/log.h"
 #include "memory_scanner/scanner.h"
 #include "hooks/memory/engine_allocator.h"
 #include "hooks/game/mass_spawner_activate/mass_spawner_activate.h"
@@ -89,9 +90,10 @@ namespace Hooks::EngineInit
 	static bool g_engineInitialized = false;
 	static long g_callCount = 0;
 
-	// Sync handles set by SetSyncEvents() before Install() is called.
+	// Sync handles set before Install() is called.
 	static HANDLE g_engineReadyEventHandle = nullptr;
 	static HANDLE g_pluginsLoadedEventHandle = nullptr;
+	static HANDLE g_pluginsReadyEventHandle = nullptr;
 
 	// Signalled at the very end of each detour (after NotifyEngineReady returns)
 	// so the UE4SS loader thread wakes up only once the hook call-stack has
@@ -101,11 +103,22 @@ namespace Hooks::EngineInit
 	// Callback for plugins to receive engine init events
 	static std::vector<PluginEngineInitCallback> g_pluginCallbacks;
 
-	// Signal the init thread that the engine hook fired, then block until
+	// Signal the init thread that the engine is ready, then block the main
+	// thread until all plugins have been initialised.
 	static void WaitForPluginsToLoad()
 	{
 		if (g_engineReadyEventHandle)
 			SetEvent(g_engineReadyEventHandle);
+
+		if (g_pluginsReadyEventHandle)
+		{
+			LogToFile::Info("[EngineInit] Main thread sleeping -- waiting for plugins to initialise");
+			const DWORD result = WaitForSingleObject(g_pluginsReadyEventHandle, 120000);
+			if (result == WAIT_TIMEOUT)
+				LogToFile::Warn("[EngineInit] Timed out waiting for plugins -- resuming main thread anyway");
+			else
+				LogToFile::Info("[EngineInit] Plugins ready -- main thread resuming");
+		}
 	}
 
 	// Shared notification function - called by any successful hook
@@ -174,8 +187,6 @@ namespace Hooks::EngineInit
 		ModLoaderLogger::LogInfo(L"[EngineInit] FEngineLoop::Init called (#%ld)", callNum);
 		ModLoaderLogger::LogDebug(L"[EngineInit]   FEngineLoop=%p, Thread=%lu", thisPtr, GetCurrentThreadId());
 
-		WaitForPluginsToLoad();
-
 		// Call original under SEH so any crash is logged with full register context
 		int32_t result = 0;
 		if (g_engineLoopOriginal)
@@ -215,8 +226,10 @@ namespace Hooks::EngineInit
 			ModLoaderLogger::LogError(L"[EngineInit] Original function pointer is null!");
 		}
 
-		// Notify plugins that engine is ready
+		// Notify plugins that engine is ready, then sleep the main thread until
+		// the init thread has finished initialising all plugins.
 		NotifyEngineReady(L"FEngineLoop::Init");
+		WaitForPluginsToLoad();
 
 		// Signal UE4SS loader thread: hook call-stack is fully unwound after
 		// this point, so it is safe to call LoadLibraryW(ue4ss.dll).
@@ -235,8 +248,6 @@ namespace Hooks::EngineInit
 		ModLoaderLogger::LogInfo(L"[EngineInit] UGameEngine::Init called (#%ld)", callNum);
 		ModLoaderLogger::LogDebug(L"[EngineInit]   GameEngine=%p, EngineLoop=%p, Thread=%lu",
 		                          thisPtr, InEngineLoop, GetCurrentThreadId());
-
-		WaitForPluginsToLoad();
 
 		// Call original under SEH so any crash deep inside (e.g. during UEngine::Browse
 		// or WorldBeginPlay subsystem hooks) is caught and logged with full register context.
@@ -278,8 +289,10 @@ namespace Hooks::EngineInit
 			ModLoaderLogger::LogError(L"[EngineInit] Original function pointer is null!");
 		}
 
-		// Notify plugins that engine is ready (if not already notified)
+		// Notify plugins that engine is ready, then sleep the main thread until
+		// the init thread has finished initialising all plugins.
 		NotifyEngineReady(L"UGameEngine::Init");
+		WaitForPluginsToLoad();
 
 		// Signal UE4SS loader thread: hook call-stack is fully unwound after
 		// this point, so it is safe to call LoadLibraryW(ue4ss.dll).
@@ -299,6 +312,11 @@ namespace Hooks::EngineInit
 	void SetUE4SSReadyEvent(HANDLE ue4ssReadyEvent)
 	{
 		g_ue4ssReadyEventHandle = ue4ssReadyEvent;
+	}
+
+	void SetPluginsReadyEvent(HANDLE pluginsReadyEvent)
+	{
+		g_pluginsReadyEventHandle = pluginsReadyEvent;
 	}
 
 	bool Install()

--- a/Version_Mod_Loader/hooks/game/engine_init/engine_init.h
+++ b/Version_Mod_Loader/hooks/game/engine_init/engine_init.h
@@ -32,6 +32,11 @@ namespace Hooks::EngineInit
 	// hook call-stack or GPU driver initialisation is still active.
 	void SetUE4SSReadyEvent(HANDLE ue4ssReadyEvent);
 
+	// Provide the event the detour should wait on after engine init completes.
+	// The main thread will block here until the init thread signals that all
+	// plugins have been fully initialised.
+	void SetPluginsReadyEvent(HANDLE pluginsReadyEvent);
+
 	// Install the hooks (tries multiple patterns for reliability)
 	// Returns true if at least one hook was successful
 	bool Install();

--- a/Version_Mod_Loader/plugins/plugin_interface.h
+++ b/Version_Mod_Loader/plugins/plugin_interface.h
@@ -22,8 +22,11 @@
 //      SetWindowFontScale, GetContentRegionAvail, GetDisplaySize).
 //      Added PluginWindowHints struct and windowHints field to PluginWidgetDesc.
 //      MIN remains 23.
+// v31: Added extra_window_flags to PluginWindowHints.
+//      Allows plugins to pass additional ImGuiWindowFlags (e.g. NoTitleBar, NoResize).
+//      0 = no extra flags (default behaviour unchanged). MIN remains 26.
 #define PLUGIN_INTERFACE_VERSION_MIN 26
-#define PLUGIN_INTERFACE_VERSION_MAX 30
+#define PLUGIN_INTERFACE_VERSION_MAX 31
 #define PLUGIN_INTERFACE_VERSION PLUGIN_INTERFACE_VERSION_MAX
 
 enum class PluginLogLevel { Trace = 0, Debug = 1, Info = 2, Warn = 3, Error = 4 };
@@ -310,6 +313,16 @@ struct IModLoaderImGui
 
 typedef void (*PluginImGuiRenderCallback)(IModLoaderImGui* imgui);
 
+// Flags for PluginWindowHints::extra_window_flags (v31).
+// Values mirror ImGuiWindowFlags so plugins do not need imgui.h.
+#define PluginWindowFlags_NoTitleBar        (1 << 0)
+#define PluginWindowFlags_NoResize          (1 << 1)
+#define PluginWindowFlags_NoMove            (1 << 2)
+#define PluginWindowFlags_NoScrollbar       (1 << 3)
+#define PluginWindowFlags_NoBackground      (1 << 7)
+#define PluginWindowFlags_NoSavedSettings   (1 << 8)
+#define PluginWindowFlags_NoMouseInputs     (1 << 9)
+
 // Optional size/position hints for RegisterWidget windows.
 // Set width/height to 0 for no size hint. Set pos_x/pos_y to -1 to skip positioning.
 // size_cond / pos_cond: 0 = Always, 1 = FirstUseEver.
@@ -323,6 +336,7 @@ struct PluginWindowHints
 	float pivot_y;
 	int   size_cond;
 	int   pos_cond;
+	int   extra_window_flags;  // v31: OR'd into ImGuiWindowFlags; 0 = default
 };
 
 struct PluginPanelDesc

--- a/Version_Mod_Loader/utils/thread_utils.h
+++ b/Version_Mod_Loader/utils/thread_utils.h
@@ -66,3 +66,29 @@ inline auto get_main_thread_id() -> DWORD
     CloseHandle(snapshot);
     return mainThreadId;
 }
+
+// Suspends the main game thread and returns an open handle to it.
+// Returns NULL if the main thread cannot be identified or opened.
+// The caller must pass the handle back to resume_main_thread().
+inline HANDLE suspend_main_thread()
+{
+    DWORD tid = get_main_thread_id();
+    if (!tid || tid == GetCurrentThreadId())
+        return NULL;
+
+    HANDLE h = OpenThread(THREAD_SUSPEND_RESUME, FALSE, tid);
+    if (!h)
+        return NULL;
+
+    SuspendThread(h);
+    return h;
+}
+
+// Resumes the main game thread and closes the handle returned by suspend_main_thread().
+inline void resume_main_thread(HANDLE h)
+{
+    if (!h)
+        return;
+    ResumeThread(h);
+    CloseHandle(h);
+}


### PR DESCRIPTION
- F2 now closes the modloader menu again when pressed
- Modloader will now pause the game thread when its pattern scanning and loading plugins.  This ensures plugins can install hooks early enough to still work instead of allowing the main thread to run away
- Added ImGui extra flags which allow for widgets/windows to be created without title bars, being resized etc etc
- AutoUpdater now runs just before the plugins are due to be loaded.  This is moved as the main game thread is paused during this, allowing for the updater to finish cleanly.
- ModLoader hooks Engine Init AOB's earlier, it should help with not detecting that the engine is ready on some systems.