### PR TITLE
Suppress plugin keybinds while a game text field is focused

### DIFF
--- a/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj
+++ b/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj
@@ -417,6 +417,7 @@
     <ClInclude Include="hooks\game\crafting_finished\crafting_finished.h" />
     <ClInclude Include="hooks\game\delegate_hook\delegate_hook.h" />
     <ClInclude Include="hooks\game\gobject_walk\gobject_walk.h" />
+    <ClInclude Include="hooks\game\text_input_focus\text_input_focus.h" />
     <ClInclude Include="hooks\game\object_properties\object_properties.h" />
     <ClInclude Include="hooks\game\engine_init\engine_init.h" />
     <ClInclude Include="hooks\game\game_instance_init\game_instance_init.h" />
@@ -510,6 +511,9 @@
     <ClCompile Include="hooks\game\crafting_finished\crafting_finished.cpp" />
     <ClCompile Include="hooks\game\delegate_hook\delegate_hook.cpp" />
     <ClCompile Include="hooks\game\gobject_walk\gobject_walk.cpp" />
+    <ClCompile Include="hooks\game\text_input_focus\text_input_focus.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)' != 'Client Debug' And '$(Configuration)' != 'Client Release' And '$(Configuration)' != 'Local SDK Client Debug' And '$(Configuration)' != 'Local SDK Client Release'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="hooks\game\object_properties\object_properties.cpp" />
     <ClCompile Include="hooks\game\engine_init\engine_init.cpp" />
     <ClCompile Include="hooks\game\game_instance_init\game_instance_init.cpp" />

--- a/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj.filters
+++ b/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj.filters
@@ -73,6 +73,9 @@
     <Filter Include="Source Files\hooks\game\gobject_walk">
       <UniqueIdentifier>{2f4a7d9b-6c8e-4a1f-b3d2-9e5c7a8f0d1b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\hooks\game\text_input_focus">
+      <UniqueIdentifier>{b8a4a9b2-5369-4f37-a5c1-ac05ed6c3333}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\hooks\game\object_properties">
       <UniqueIdentifier>{3a5b8e0c-7d9f-4b2a-9e6f-8c1d3a4b5c6d}</UniqueIdentifier>
     </Filter>
@@ -206,6 +209,9 @@
     </ClInclude>
     <ClInclude Include="hooks\game\gobject_walk\gobject_walk.h">
       <Filter>Source Files\hooks\game\gobject_walk</Filter>
+    </ClInclude>
+    <ClInclude Include="hooks\game\text_input_focus\text_input_focus.h">
+      <Filter>Source Files\hooks\game\text_input_focus</Filter>
     </ClInclude>
     <ClInclude Include="hooks\game\object_properties\object_properties.h">
       <Filter>Source Files\hooks\game\object_properties</Filter>
@@ -430,6 +436,9 @@
     </ClCompile>
     <ClCompile Include="hooks\game\gobject_walk\gobject_walk.cpp">
       <Filter>Source Files\hooks\game\gobject_walk</Filter>
+    </ClCompile>
+    <ClCompile Include="hooks\game\text_input_focus\text_input_focus.cpp">
+      <Filter>Source Files\hooks\game\text_input_focus</Filter>
     </ClCompile>
     <ClCompile Include="hooks\game\object_properties\object_properties.cpp">
       <Filter>Source Files\hooks\game\object_properties</Filter>

--- a/StarRupture-ModLoader-Core/core/client_ui.cpp
+++ b/StarRupture-ModLoader-Core/core/client_ui.cpp
@@ -3,6 +3,7 @@
 #include "client_ui.h"
 #include "startup_utils.h"
 #include "Engine_classes.hpp"
+#include "../hooks/game/text_input_focus/text_input_focus.h"
 #include "../hooks/game/world_begin_play/world_begin_play.h"
 #include "../hooks/game/engine_tick/engine_tick.h"
 #include "../hooks/input/input_processor.h"
@@ -26,6 +27,7 @@ static EModKey      s_openKey      = EModKey::F2;
 void InitClientUI()
 {
     const std::wstring iniPath = GetModLoaderDirPath(L"modloader.ini");
+    Hooks::TextInputFocus::LoadConfig(iniPath.c_str());
     int val = GetPrivateProfileIntW(L"UI", L"Enabled", -1, iniPath.c_str());
     if (val == -1)
     {

--- a/StarRupture-ModLoader-Core/hooks/game/text_input_focus/text_input_focus.cpp
+++ b/StarRupture-ModLoader-Core/hooks/game/text_input_focus/text_input_focus.cpp
@@ -1,0 +1,97 @@
+#include "pch.h"
+#include "text_input_focus.h"
+
+// Client-only feature -- entire translation unit is a no-op on server/generic builds.
+#ifdef MODLOADER_CLIENT_BUILD
+
+#include "hooks/game/gobject_walk/gobject_walk.h"
+#include "logging/logger.h"
+#include "UMG_classes.hpp"
+
+#include <windows.h>
+
+namespace Hooks::TextInputFocus
+{
+	static bool s_suppressEnabled = true;
+
+	void LoadConfig(const wchar_t* iniPath)
+	{
+		int val = GetPrivateProfileIntW(L"Input", L"SuppressKeybindsWhileTyping", -1, iniPath);
+		if (val == -1)
+		{
+			WritePrivateProfileStringW(L"Input", L"SuppressKeybindsWhileTyping", L"1", iniPath);
+			val = 1;
+		}
+		s_suppressEnabled = (val != 0);
+		ModLoaderLogger::LogInfo(L"[TextInputFocus] SuppressKeybindsWhileTyping=%d", val);
+	}
+
+	// -----------------------------------------------------------------------
+	// SEH-protected scan.
+	//
+	// Deliberately does NOT reuse GObjectWalk::FindObjectsByClassNameInto --
+	// that builds a std::string class name for every live object per walk,
+	// which is far too slow to run per keypress.  Comparing UClass pointers
+	// keeps the pass sub-millisecond.
+	//
+	// Same residual risk as the GObjectWalk plugin API: an object mid-GC can
+	// slip past the flag filter (EInternalObjectFlags is not in this SDK
+	// dump), so the walk and the ProcessEvent focus query are wrapped in SEH.
+	// POD locals only in this function -- SEH forbids unwindable objects.
+	// -----------------------------------------------------------------------
+	static bool ScanForFocusedTextWidget(SDK::UClass* c0, SDK::UClass* c1,
+	                                     SDK::UClass* c2, SDK::UClass* c3)
+	{
+		__try
+		{
+			const int32_t num = SDK::UObject::GObjects->Num();
+			for (int32_t i = 0; i < num; ++i)
+			{
+				SDK::UObject* obj = SDK::UObject::GObjects->GetByIndex(i);
+				if (!obj || !obj->Class)
+					continue;
+				if (obj->Flags & SDK::EObjectFlags::BeginDestroyed)
+					continue;
+				if (obj->Flags & SDK::EObjectFlags::FinishDestroyed)
+					continue;
+				if (obj->Flags & SDK::EObjectFlags::ClassDefaultObject)
+					continue;
+				if (obj->Flags & SDK::EObjectFlags::ArchetypeObject)
+					continue;
+
+				SDK::UClass* cls = obj->Class;
+				if (cls != c0 && cls != c1 && cls != c2 && cls != c3)
+					continue;
+
+				if (static_cast<SDK::UWidget*>(obj)->HasKeyboardFocus())
+					return true;
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER)
+		{
+			return false;
+		}
+		return false;
+	}
+
+	bool IsGameTextInputFocused()
+	{
+		if (!s_suppressEnabled)
+			return false;
+		if (!Hooks::GObjectWalk::IsReady())
+			return false;
+
+		// StaticClass() caches its lookup in a function-local static, so
+		// calling these every time is cheap.  A null result (class not found)
+		// can never match obj->Class because null-Class objects are skipped.
+		SDK::UClass* c0 = SDK::UEditableText::StaticClass();
+		SDK::UClass* c1 = SDK::UEditableTextBox::StaticClass();
+		SDK::UClass* c2 = SDK::UMultiLineEditableText::StaticClass();
+		SDK::UClass* c3 = SDK::UMultiLineEditableTextBox::StaticClass();
+
+		return ScanForFocusedTextWidget(c0, c1, c2, c3);
+	}
+
+} // namespace Hooks::TextInputFocus
+
+#endif // MODLOADER_CLIENT_BUILD

--- a/StarRupture-ModLoader-Core/hooks/game/text_input_focus/text_input_focus.h
+++ b/StarRupture-ModLoader-Core/hooks/game/text_input_focus/text_input_focus.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// Game text-input focus detection (client only)
+//
+// Answers "does any UMG editable-text widget currently have keyboard focus?"
+// so keybind dispatch can be suppressed while the player is typing into a
+// game text field (chat box, save name, etc.).  Without this, a plugin bound
+// to a letter key (e.g. "P") would fire while the player types that letter
+// into a game text box.
+//
+// Detection walks GObjects comparing UClass pointers against the four stock
+// UMG editable-text classes (UEditableText, UEditableTextBox,
+// UMultiLineEditableText, UMultiLineEditableTextBox) and asks each live
+// instance for keyboard focus via the reflected UWidget::HasKeyboardFocus.
+// The current SDK dump has no game-specific subclasses of any of these; if
+// the game ever adds one it must be added to the class list in the .cpp.
+//
+// Cost: one pointer-compare pass over GObjects plus a ProcessEvent call per
+// live editable widget (typically 0-3).  Callers keep this off the hot path
+// by only querying for keys that actually have a registered keybind.
+// ---------------------------------------------------------------------------
+
+namespace Hooks::TextInputFocus
+{
+	// Read [Input] SuppressKeybindsWhileTyping from modloader.ini (default 1,
+	// written back if absent so users can discover the toggle).  Call once at
+	// startup before keybind dispatch begins.
+	void LoadConfig(const wchar_t* iniPath);
+
+	// True when suppression is enabled, the engine is initialized, and a live
+	// UMG editable-text widget currently has keyboard focus.  Returns false
+	// before engine init.  Must be called on the game thread (calls
+	// ProcessEvent on game objects).
+	bool IsGameTextInputFocused();
+}

--- a/StarRupture-ModLoader-Core/hooks/input/keybind_registry.cpp
+++ b/StarRupture-ModLoader-Core/hooks/input/keybind_registry.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "keybind_registry.h"
+#include "hooks/game/text_input_focus/text_input_focus.h"
 #include "logging/logger.h"
 
 #include <windows.h>
@@ -575,6 +576,23 @@ namespace Hooks::Input
 	}
 
 	// -----------------------------------------------------------------------
+	// Registration precheck -- true if any registration (simple, named combo,
+	// or advanced combo) exists for the key.  Used to keep the game text-focus
+	// scan off the hot path for keys nothing is bound to.
+	// -----------------------------------------------------------------------
+	static bool HasAnyRegistrationForKey(EModKey key)
+	{
+		std::lock_guard<std::mutex> lock(s_mutex);
+		for (auto& e : s_callbacks)
+			if (e.key == key) return true;
+		for (auto& e : s_namedCombos)
+			if (e.key == key) return true;
+		for (auto& e : s_comboCallbacks)
+			if (e.key == key) return true;
+		return false;
+	}
+
+	// -----------------------------------------------------------------------
 	// Dispatch
 	// -----------------------------------------------------------------------
 	void Dispatch(EModKey key, EModKeyEvent event)
@@ -707,6 +725,18 @@ namespace Hooks::Input
 		if (vk == VK_LCONTROL || vk == VK_RCONTROL ||
 		    vk == VK_LSHIFT   || vk == VK_RSHIFT   ||
 		    vk == VK_LMENU    || vk == VK_RMENU)
+			return false;
+
+		// Do not fire keyboard keybinds while the player is typing into a
+		// game text field (chat, save name, etc.) -- e.g. a plugin bound to
+		// "P" must not open its panel when the player types "Printer".
+		// Returning false (not blocked) lets the keystroke flow on to the
+		// game so it reaches the text box.  Only Pressed is gated: letting
+		// Released through means a key held when focus changed does not get
+		// stuck down in a plugin's view.  Mouse buttons are unaffected.
+		if ((msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) &&
+		    HasAnyRegistrationForKey(mk) &&
+		    Hooks::TextInputFocus::IsGameTextInputFocused())
 			return false;
 
 		EModKeyModifiers mods = SampleCurrentModifiers();


### PR DESCRIPTION
New client-only module hooks/game/text_input_focus queries the four stock UMG editable-text classes for keyboard focus via a class-pointer GObjects walk plus reflected UWidget::HasKeyboardFocus. ProcessWindowMessage gates keyboard Pressed dispatch on it, prechecked by key registration so unbound keys never trigger the scan. Toggle via [Input] SuppressKeybindsWhileTyping in modloader.ini (default on).