### PR TITLE
Add marquee config labels and inline boolean descriptions

### DIFF
--- a/StarRupture-ModLoader-Core/UI/modloader_window.cpp
+++ b/StarRupture-ModLoader-Core/UI/modloader_window.cpp
@@ -329,18 +329,21 @@ namespace UI::ModLoaderWindow
         ImGui::SetNextItemWidth(-FLT_MIN); // fill the column
 
         bool widgetHovered = false;
+        const bool isBool = e && e->type == ConfigValueType::Boolean;
 
-        if (e && e->type == ConfigValueType::Boolean)
+        if (isBool)
         {
-            bool bval = (strcmp(kv.value, "true") == 0 || strcmp(kv.value, "1") == 0);
-            char lbl[128];
-            snprintf(lbl, sizeof(lbl), "##chk%s", id);
-            if (UI::Theme::ToggleSwitch(lbl, &bval))
+            // The toggle itself lives in Col 2 (next to reset); this column shows
+            // the description inline as a marquee so it is readable without a
+            // hover tooltip, scrolling only when it overflows the column.
+            if (e && e->description && e->description[0])
             {
-                strncpy_s(kv.value, bval ? "true" : "false", _TRUNCATE);
-                CommitConfigChange(pluginName, kv);
+                char descId[160];
+                snprintf(descId, sizeof(descId), "##desc%s", id);
+                ImGui::AlignTextToFramePadding();
+                UI::Theme::MarqueeLabel(descId, e->description,
+                                        ImGui::GetContentRegionAvail().x);
             }
-            widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
         }
         else if (e && e->type == ConfigValueType::Integer)
         {
@@ -430,6 +433,21 @@ namespace UI::ModLoaderWindow
 
         // ---- Col 2: actions ----------------------------------------------
         ImGui::TableSetColumnIndex(2);
+
+        // Boolean toggle lives here (not in Col 1) so the description marquee
+        // can use the full widget column width.
+        if (isBool)
+        {
+            bool bval = (strcmp(kv.value, "true") == 0 || strcmp(kv.value, "1") == 0);
+            char lbl[128];
+            snprintf(lbl, sizeof(lbl), "##chk%s", id);
+            if (UI::Theme::ToggleSwitch(lbl, &bval))
+            {
+                strncpy_s(kv.value, bval ? "true" : "false", _TRUNCATE);
+                CommitConfigChange(pluginName, kv);
+            }
+            ImGui::SameLine();
+        }
 
         // Blocking checkbox (keybind rows only).
         if (e && e->type == ConfigValueType::Keybind)

--- a/StarRupture-ModLoader-Core/UI/theme.cpp
+++ b/StarRupture-ModLoader-Core/UI/theme.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cfloat>
+#include <unordered_map>
 
 // FindGlyph(), ImFont::FontSize, and ImTextCharFromUtf8() used by
 // IconTabBar() for glyph-bbox centering are internal-only APIs -- not
@@ -463,6 +464,68 @@ namespace UI::Theme
         }
 
         return changed;
+    }
+
+    void MarqueeLabel(const char* id, const char* text, float width)
+    {
+        if (width <= 0.0f)
+            width = ImGui::GetContentRegionAvail().x;
+
+        const ImVec2 textSize = ImGui::CalcTextSize(text);
+        const float  lineH    = ImGui::GetTextLineHeight();
+        const ImVec2 pos      = ImGui::GetCursorScreenPos();
+
+        // Reserve the box so the cursor advances like a normal text item and
+        // tables/SameLine() lay out correctly regardless of scroll state.
+        ImGui::Dummy(ImVec2(width, lineH));
+
+        ImDrawList* draw = ImGui::GetWindowDrawList();
+        const ImU32 col  = ImGui::GetColorU32(ImGuiCol_Text);
+        const float overflow = textSize.x - width;
+
+        if (overflow <= 0.0f)
+        {
+            // Fits -- draw statically, no scroll state needed.
+            draw->AddText(pos, col, text);
+            return;
+        }
+
+        // Per-label scroll phase, keyed by a stable id. Phase runs 0..1 forward
+        // (scroll left), holds at each end, then reverses -- a ping-pong so both
+        // ends of the string are readable.
+        static std::unordered_map<ImGuiID, float> s_phase;
+        const ImGuiID key = ImGui::GetID(id);
+        float& phase = s_phase[key];
+
+        // Speed is in pixels/sec; convert to phase/sec over the overflow span so
+        // long and short overflows scroll at a consistent visual rate.
+        const float kPixelsPerSec = 30.0f;
+        const float kPauseSecs    = 1.2f;
+        const float span          = overflow;
+        const float dt            = ImGui::GetIO().DeltaTime;
+
+        // Encode pause into the phase range: [-pauseFrac, 0] left hold,
+        // [1, 1+pauseFrac] right hold, wrapping via a triangle wave over a
+        // period that includes both holds.
+        const float scrollSecs = span / kPixelsPerSec;
+        const float period     = 2.0f * (scrollSecs + kPauseSecs);
+        phase += dt;
+        if (phase >= period) phase -= period * (float)(int)(phase / period);
+
+        float t = phase;
+        float scroll; // 0 = fully left (start), 1 = fully right (end shown)
+        if (t < kPauseSecs)                              scroll = 0.0f;                       // hold start
+        else if (t < kPauseSecs + scrollSecs)            scroll = (t - kPauseSecs) / scrollSecs;
+        else if (t < 2.0f * kPauseSecs + scrollSecs)     scroll = 1.0f;                       // hold end
+        else                                             scroll = 1.0f - (t - (2.0f * kPauseSecs + scrollSecs)) / scrollSecs;
+
+        const float offset = scroll * overflow;
+
+        // Clip to the reserved box so the scrolled text does not bleed into
+        // neighbouring columns/widgets.
+        draw->PushClipRect(pos, ImVec2(pos.x + width, pos.y + lineH), true);
+        draw->AddText(ImVec2(pos.x - offset, pos.y), col, text);
+        draw->PopClipRect();
     }
 
     namespace Icons

--- a/StarRupture-ModLoader-Core/UI/theme.h
+++ b/StarRupture-ModLoader-Core/UI/theme.h
@@ -58,6 +58,15 @@ namespace UI::Theme
     // returns true the frame the value changes.
     bool ToggleSwitch(const char* label, bool* v);
 
+    // Draws `text` clipped to `width` pixels on the current line. If it fits,
+    // it is drawn statically like TextUnformatted. If it overflows, it scrolls
+    // horizontally (pause at each end, then reverse) so the whole string can be
+    // read without a tooltip. `id` must be stable across frames -- it keys the
+    // per-label scroll state -- and is not rendered (pass e.g. "##desc_foo").
+    // Advances the cursor by one line height and reserves `width` horizontally,
+    // so it composes with SameLine()/tables like a normal text item.
+    void MarqueeLabel(const char* id, const char* text, float width);
+
     // Draws a single-diagonal-corner (chamfered) outline -- chamfer cut at
     // the top-left and bottom-right corners -- over the given rect, matching
     // the angular panel shape used throughout the StarRupture HUD. Call after


### PR DESCRIPTION
Adds `UI::Theme::MarqueeLabel`, a clipped text helper that scrolls horizontally (ping-pong with a pause at each end) only when the text overflows its column. Per-label scroll state is keyed by a stable id, and text that fits is drawn statically with no animation.

Uses it in the plugin config UI: boolean rows now show their description inline in the widget column, and the toggle switch moves to the actions column next to the reset button. Non-boolean rows are unchanged (widget in col 1, description still on hover).

## Notes for review
- Scroll speed (30 px/s) and end pause (1.2s) are constants at the top of the overflow branch in `theme.cpp` and easy to tune.
- `s_phase` state map is bounded by the number of distinct config descriptions.