### PR TITLE
Disable crash report uploads and show a local crash notice instead

### DIFF
--- a/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj
+++ b/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj
@@ -415,6 +415,7 @@
     <ClInclude Include="config\config_manager.h" />
     <ClInclude Include="hooks\game\actor_begin_play\actor_begin_play.h" />
     <ClInclude Include="hooks\game\crafting_finished\crafting_finished.h" />
+    <ClInclude Include="hooks\game\crash_reporter\crash_reporter.h" />
     <ClInclude Include="hooks\game\delegate_hook\delegate_hook.h" />
     <ClInclude Include="hooks\game\gobject_walk\gobject_walk.h" />
     <ClInclude Include="hooks\game\text_input_focus\text_input_focus.h" />
@@ -510,6 +511,7 @@
     <ClCompile Include="core\core_entry.cpp" />
     <ClCompile Include="hooks\game\actor_begin_play\actor_begin_play.cpp" />
     <ClCompile Include="hooks\game\crafting_finished\crafting_finished.cpp" />
+    <ClCompile Include="hooks\game\crash_reporter\crash_reporter.cpp" />
     <ClCompile Include="hooks\game\delegate_hook\delegate_hook.cpp" />
     <ClCompile Include="hooks\game\gobject_walk\gobject_walk.cpp" />
     <ClCompile Include="hooks\game\text_input_focus\text_input_focus.cpp">

--- a/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj.filters
+++ b/StarRupture-ModLoader-Core/StarRupture-ModLoader-Core.vcxproj.filters
@@ -70,6 +70,9 @@
     <Filter Include="Source Files\hooks\game\crafting_finished">
       <UniqueIdentifier>{8b3c1f2e-4d5a-4e6b-9c7d-1a2b3c4d5e6f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\hooks\game\crash_reporter">
+      <UniqueIdentifier>{9c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\hooks\game\gobject_walk">
       <UniqueIdentifier>{2f4a7d9b-6c8e-4a1f-b3d2-9e5c7a8f0d1b}</UniqueIdentifier>
     </Filter>
@@ -209,6 +212,9 @@
     </ClInclude>
     <ClInclude Include="hooks\game\crafting_finished\crafting_finished.h">
       <Filter>Source Files\hooks\game\crafting_finished</Filter>
+    </ClInclude>
+    <ClInclude Include="hooks\game\crash_reporter\crash_reporter.h">
+      <Filter>Source Files\hooks\game\crash_reporter</Filter>
     </ClInclude>
     <ClInclude Include="hooks\game\gobject_walk\gobject_walk.h">
       <Filter>Source Files\hooks\game\gobject_walk</Filter>
@@ -439,6 +445,9 @@
     </ClCompile>
     <ClCompile Include="hooks\game\crafting_finished\crafting_finished.cpp">
       <Filter>Source Files\hooks\game\crafting_finished</Filter>
+    </ClCompile>
+    <ClCompile Include="hooks\game\crash_reporter\crash_reporter.cpp">
+      <Filter>Source Files\hooks\game\crash_reporter</Filter>
     </ClCompile>
     <ClCompile Include="hooks\game\gobject_walk\gobject_walk.cpp">
       <Filter>Source Files\hooks\game\gobject_walk</Filter>

--- a/StarRupture-ModLoader-Core/UI/modloader_window.cpp
+++ b/StarRupture-ModLoader-Core/UI/modloader_window.cpp
@@ -801,6 +801,21 @@ namespace UI::ModLoaderWindow
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("Populates the plugin-updated popup with fake\n"
                               "entries and opens it. Debug builds only.");
+
+        if (ImGui::Button("Crash Game (YOLO)"))
+        {
+            // Deliberate null-pointer write -- raises a real SEH access violation
+            // so it flows through the engine's crash reporting thread exactly
+            // like an organic crash, exercising the CrashReporter hook.
+            volatile int* crashPtr = nullptr;
+            *crashPtr = 1;
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Immediately crashes the game with a null pointer write, to\n"
+                              "verify the CrashReporter hook shows its own dialog instead of\n"
+                              "spawning CrashReportClient.exe. Debug builds only.");
 #endif
     }
 

--- a/StarRupture-ModLoader-Core/core/hook_management.cpp
+++ b/StarRupture-ModLoader-Core/core/hook_management.cpp
@@ -27,9 +27,22 @@
 #include "../hooks/http/http_server_hook.h"
 #endif
 
+#ifdef MODLOADER_CLIENT_BUILD
+#include "../hooks/game/crash_reporter/crash_reporter.h"
+#endif
+
 void InstallAllHooks()
 {
     ModLoaderLogger::LogMessage(L"Installing core game hooks...");
+
+#ifdef MODLOADER_CLIENT_BUILD
+    Splash::SetStatus(L"Installing CrashReporter hook...");
+
+    if (Hooks::CrashReporter::Install())
+        ModLoaderLogger::LogDebug(L"  CrashReporter hook installed");
+    else
+        ModLoaderLogger::LogWarn(L"  WARNING: CrashReporter hook failed -- crash reports will still be sent to the developers");
+#endif
 
     Splash::SetStatus(L"Installing EngineInit hook...");
     Splash::SetProgress(0.20f);
@@ -111,7 +124,6 @@ void InstallAllHooks()
         ModLoaderLogger::LogDebug(L"  GameInstanceInit hook installed");
     else
         ModLoaderLogger::LogWarn(L"  WARNING: GameInstanceInit hook failed -- plugins will not be initialized");
-
 }
 
 void RemoveAllHooks()
@@ -132,5 +144,8 @@ void RemoveAllHooks()
     Hooks::TextKey::Remove();
 #ifdef MODLOADER_SERVER_BUILD
     Hooks::HttpServer::Remove();
+#endif
+#ifdef MODLOADER_CLIENT_BUILD
+    Hooks::CrashReporter::Remove();
 #endif
 }

--- a/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.cpp
+++ b/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.cpp
@@ -1,0 +1,203 @@
+#include "pch.h"
+#include "crash_reporter.h"
+#include "logging/logger.h"
+#include "memory_scanner/scanner.h"
+#include "../scan_patterns.h"
+#include <DbgHelp.h>
+#pragma comment(lib, "DbgHelp.lib")
+
+namespace Hooks::CrashReporter
+{
+	// anonymous_namespace_::ReportCrashUsingCrashReportClient(FWindowsPlatformCrashContext* InContext,
+	//   _EXCEPTION_POINTERS* ExceptionInfo, EErrorReportUI ReportUI)
+	using ReportCrashUsingCrashReportClient_t = int64_t(__fastcall*)(void* inContext, void* exceptionInfo, int32_t reportUI);
+
+	static Hook g_hook;
+	static ReportCrashUsingCrashReportClient_t g_original = nullptr;
+
+	// Return address of the one call site inside FCrashReportingThread::HandleCrashInternal
+	// that reports a real fatal crash. 0 until resolved in Install() -- if it can never be
+	// resolved, the detour always falls through to the original (fail safe: never suppress
+	// ensure()/hang reports it can't positively identify as fatal).
+	static uintptr_t g_fatalCrashReturnAddr = 0;
+
+	// Walks the crashing thread's call stack from the captured CONTEXT and logs one line per
+	// frame: module name, symbol name (demangled Class::Func if PDBs are available, otherwise
+	// just the raw address), and both a symbol-relative and module-relative offset.
+	//
+	// StackWalk64 is given a copy of the CONTEXT captured at the moment of the fault (from
+	// ExceptionInfo->ContextRecord) rather than a live thread handle -- on x64 the unwind is
+	// driven entirely by that CONTEXT plus the module's .pdata (SymFunctionTableAccess64), so
+	// GetCurrentThread() is passed as a formality only.
+	static void LogStackTrace(const CONTEXT* contextRecord)
+	{
+		HANDLE process = GetCurrentProcess();
+
+		// The engine may already have called SymInitialize for this process by the time a
+		// crash happens -- a second call just fails harmlessly, so ignore the return value.
+		static bool s_symOptionsSet = false;
+		if (!s_symOptionsSet)
+		{
+			s_symOptionsSet = true;
+			SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+			SymInitialize(process, nullptr, TRUE);
+		}
+
+		CONTEXT ctx = *contextRecord; // StackWalk64 mutates this as it unwinds
+
+		STACKFRAME64 frame{};
+		frame.AddrPC.Offset = ctx.Rip;
+		frame.AddrPC.Mode = AddrModeFlat;
+		frame.AddrFrame.Offset = ctx.Rbp;
+		frame.AddrFrame.Mode = AddrModeFlat;
+		frame.AddrStack.Offset = ctx.Rsp;
+		frame.AddrStack.Mode = AddrModeFlat;
+
+		ModLoaderLogger::LogError(L"[CrashReporter]   Stack trace:");
+
+		constexpr int kMaxFrames = 64;
+		for (int i = 0; i < kMaxFrames; ++i)
+		{
+			if (!StackWalk64(IMAGE_FILE_MACHINE_AMD64, process, GetCurrentThread(),
+					&frame, &ctx, nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr))
+				break;
+
+			DWORD64 addr = frame.AddrPC.Offset;
+			if (!addr)
+				break;
+
+			wchar_t moduleName[MAX_PATH] = L"<unknown>";
+			DWORD64 moduleBase = SymGetModuleBase64(process, addr);
+			if (moduleBase)
+			{
+				wchar_t path[MAX_PATH]{};
+				if (GetModuleFileNameW(reinterpret_cast<HMODULE>(moduleBase), path, MAX_PATH))
+				{
+					const wchar_t* slash = wcsrchr(path, L'\\');
+					wcscpy_s(moduleName, slash ? slash + 1 : path);
+				}
+			}
+			DWORD64 modDisplacement = moduleBase ? (addr - moduleBase) : 0;
+
+			uint8_t symBuffer[sizeof(SYMBOL_INFOW) + MAX_SYM_NAME * sizeof(wchar_t)]{};
+			auto* symbol = reinterpret_cast<SYMBOL_INFOW*>(symBuffer);
+			symbol->SizeOfStruct = sizeof(SYMBOL_INFOW);
+			symbol->MaxNameLen = MAX_SYM_NAME;
+
+			DWORD64 symDisplacement = 0;
+			if (SymFromAddrW(process, addr, &symDisplacement, symbol))
+			{
+				ModLoaderLogger::LogError(L"[CrashReporter]     #%02d 0x%016llX  %s!%s + 0x%llX  (module+0x%llX)",
+					i, addr, moduleName, symbol->Name, symDisplacement, modDisplacement);
+			}
+			else
+			{
+				ModLoaderLogger::LogError(L"[CrashReporter]     #%02d 0x%016llX  %s + 0x%llX",
+					i, addr, moduleName, modDisplacement);
+			}
+		}
+	}
+
+	static int64_t __fastcall Detour(void* inContext, void* exceptionInfo, int32_t reportUI)
+	{
+		if (!g_fatalCrashReturnAddr || reinterpret_cast<uintptr_t>(_ReturnAddress()) != g_fatalCrashReturnAddr)
+		{
+			// Not the fatal-crash call site (ensure() or hang report) -- unchanged behavior.
+			return g_original ? g_original(inContext, exceptionInfo, reportUI) : 0;
+		}
+
+		ModLoaderLogger::LogError(L"[CrashReporter] *** FATAL ENGINE CRASH *** -- suppressing CrashReportClient upload");
+
+		// ExceptionInfo is a plain Win32 _EXCEPTION_POINTERS* (not an engine-internal type),
+		// so we can log the fault details directly into ModLoader.log without needing the
+		// engine's own FWindowsPlatformCrashContext serialization.
+		auto* exceptionPointers = static_cast<EXCEPTION_POINTERS*>(exceptionInfo);
+		if (exceptionPointers && exceptionPointers->ExceptionRecord && exceptionPointers->ContextRecord)
+		{
+			const EXCEPTION_RECORD* record = exceptionPointers->ExceptionRecord;
+			const CONTEXT* ctx = exceptionPointers->ContextRecord;
+
+			HMODULE mainMod = GetModuleHandleW(nullptr);
+			auto base = reinterpret_cast<ULONG64>(mainMod);
+			auto faultAddr = reinterpret_cast<ULONG64>(record->ExceptionAddress);
+
+			ModLoaderLogger::LogError(L"[CrashReporter]   Exception : 0x%08lX", record->ExceptionCode);
+			ModLoaderLogger::LogError(L"[CrashReporter]   Fault addr: 0x%016llX  (exe+0x%llX)", faultAddr, faultAddr - base);
+			ModLoaderLogger::LogError(L"[CrashReporter]   RIP=0x%016llX  (exe+0x%llX)", ctx->Rip, ctx->Rip - base);
+			ModLoaderLogger::LogError(L"[CrashReporter]   RSP=0x%016llX  RBP=0x%016llX", ctx->Rsp, ctx->Rbp);
+			ModLoaderLogger::LogError(L"[CrashReporter]   RCX=0x%016llX  RDX=0x%016llX", ctx->Rcx, ctx->Rdx);
+			ModLoaderLogger::LogError(L"[CrashReporter]   R8 =0x%016llX  R9 =0x%016llX", ctx->R8, ctx->R9);
+			ModLoaderLogger::LogError(L"[CrashReporter]   R10=0x%016llX  R11=0x%016llX", ctx->R10, ctx->R11);
+
+			LogStackTrace(ctx);
+		}
+		else
+		{
+			ModLoaderLogger::LogError(L"[CrashReporter]   ExceptionInfo unavailable -- no fault details to log");
+		}
+
+		MessageBoxW(nullptr,
+			L"StarRupture has crashed.\n\n"
+			L"Automatic crash reporting to the developers is disabled because the ModLoader is installed.\n"
+			L"This crash report has not been sent anywhere.\n\n"
+			L"Details were written to ModLoader\\Logs\\ModLoader.log.",
+			L"StarRupture ModLoader",
+			MB_OK | MB_ICONERROR | MB_TASKMODAL);
+
+		return 0;
+	}
+
+	bool Install()
+	{
+		ModLoaderLogger::LogInfo(L"[CrashReporter] Installing hook...");
+
+		uintptr_t targetAddr = Scanner::FindPatternInMainModule(
+			"ReportCrashUsingCrashReportClient", ScanPatterns::ReportCrashUsingCrashReportClient);
+		if (!targetAddr)
+		{
+			ModLoaderLogger::LogError(L"[CrashReporter] Pattern scan failed -- hook not installed");
+			return false;
+		}
+
+		uintptr_t callSiteAddr = Scanner::FindPatternInMainModule(
+			"HandleCrashInternal_FatalReportCallSite", ScanPatterns::HandleCrashInternal_FatalReportCallSite);
+		if (callSiteAddr)
+		{
+			g_fatalCrashReturnAddr = callSiteAddr + ScanPatterns::HandleCrashInternal_FatalReportCallSite_Length;
+		}
+		else
+		{
+			ModLoaderLogger::LogWarn(L"[CrashReporter] Fatal-crash call site not found -- "
+				L"hook will install but never trigger (ensures/hangs/crashes all keep default behavior)");
+		}
+
+		bool hookOk = g_hook.Install(
+			targetAddr,
+			reinterpret_cast<void*>(&Detour),
+			reinterpret_cast<void**>(&g_original));
+
+		if (hookOk)
+			ModLoaderLogger::LogInfo(L"[CrashReporter] Hook installed successfully");
+		else
+			ModLoaderLogger::LogError(L"[CrashReporter] Hook installation failed");
+
+		return hookOk;
+	}
+
+	void Remove()
+	{
+		ModLoaderLogger::LogInfo(L"[CrashReporter] Removing hook...");
+		g_hook.Remove();
+		g_fatalCrashReturnAddr = 0;
+	}
+
+	bool IsInstalled()
+	{
+		return g_hook.installed;
+	}
+
+	uintptr_t GetOriginalPtr()
+	{
+		return reinterpret_cast<uintptr_t>(g_original);
+	}
+}

--- a/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.h
+++ b/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "../../hooks_common.h"
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// Crash Reporter Suppression Hook (client only)
+//
+// Purpose: UE5's FCrashReportingThread::HandleCrashInternal spawns
+//          CrashReportClient.exe (via anonymous_namespace_::
+//          ReportCrashUsingCrashReportClient) on a fatal engine crash, which
+//          uploads a report to the developers. Since the ModLoader hooks
+//          native engine functions, any crash while it's installed is not
+//          representative of the vanilla game and shouldn't be sent upstream.
+//
+//          ReportCrashUsingCrashReportClient is also called from two other,
+//          non-fatal paths (ReportContinuableEventUsingCrashReportClient for
+//          ensure() failures, and ReportHang for hang detection) -- those are
+//          left completely untouched. This hook only intervenes when called
+//          from the one specific call site inside HandleCrashInternal that
+//          handles a real fatal crash, identified via the return address left
+//          on the stack by that call site (see Install()).
+//
+// On a real fatal crash the detour shows a local MessageBoxW telling the
+// player the game crashed and that reporting is disabled, then returns
+// without ever spawning CrashReportClient.exe.
+// ---------------------------------------------------------------------------
+
+namespace Hooks::CrashReporter
+{
+	// Install the hook
+	bool Install();
+
+	// Remove the hook
+	void Remove();
+
+	// Returns true if the hook is currently installed
+	bool IsInstalled();
+
+	// Returns the trampoline address of the original
+	// anonymous_namespace_::ReportCrashUsingCrashReportClient, or 0 if not yet installed.
+	// Cast to: int64_t(__fastcall*)(void* InContext, void* ExceptionInfo, int32_t ReportUI)
+	uintptr_t GetOriginalPtr();
+}

--- a/StarRupture-ModLoader-Core/hooks/game/scan_patterns.h
+++ b/StarRupture-ModLoader-Core/hooks/game/scan_patterns.h
@@ -60,6 +60,32 @@ namespace ScanPatterns
 	//               UGameViewportClient* this, const FInputKeyEventArgs* InEventArgs)
 	inline constexpr auto UGameViewportClient_InputKey =
 		"48 8B C4 55 53 57 41 55 48 8D 68 ?? 48 81 EC ?? ?? ?? ?? 48 8B 5A";
+
+	// anonymous_namespace_::ReportCrashUsingCrashReportClient(FWindowsPlatformCrashContext* InContext,
+	//   _EXCEPTION_POINTERS* ExceptionInfo, EErrorReportUI ReportUI)
+	// Spawns CrashReportClient.exe and uploads the crash report to the developers. Also called
+	// (from different call sites) for non-fatal ensure() failures and hangs -- see
+	// HandleCrashInternal_FatalReportCallSite below for how the crash_reporter hook tells those
+	// apart from a real fatal crash.
+	inline constexpr auto ReportCrashUsingCrashReportClient =
+		"48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 45 33 E4 48 89 55 ?? 66 44 39 25";
+
+	// The specific call site inside FCrashReportingThread::HandleCrashInternal that invokes
+	// ReportCrashUsingCrashReportClient for a real fatal engine crash:
+	//   cmp cs:GUseCrashReportClient, r13b
+	//   lea rcx, [rsp+...]
+	//   jz  short loc_...
+	//   mov rdx, [r14+28h]   ; ExceptionInfo
+	//   xor r8d, r8d         ; ReportUI
+	//   call ReportCrashUsingCrashReportClient
+	// ReportContinuableEventUsingCrashReportClient (ensure() failures) and ReportHang (hang
+	// detection) call the same function from different call sites elsewhere in the module, so
+	// matching this exact sequence -- rather than hooking ReportCrashUsingCrashReportClient
+	// unconditionally -- lets the hook only intervene on real fatal crashes.
+	// Match length is 26 bytes; the return address for this call site is (matchAddress + 26).
+	inline constexpr auto HandleCrashInternal_FatalReportCallSite =
+		"44 38 2D ?? ?? ?? ?? 48 8D 4C 24 30 74 0E 49 8B 56 28 45 33 C0 E8 ?? ?? ?? ??";
+	inline constexpr int HandleCrashInternal_FatalReportCallSite_Length = 26;
 #endif
 
 	// UObject::ProcessEvent -- called for every UFUNCTION dispatch in the game.


### PR DESCRIPTION
Hooks the fatal-crash call site inside FCrashReportingThread::HandleCrashInternal so CrashReportClient.exe never spawns and no report reaches the developers while the ModLoader is installed. ensure()/hang reports through the same shared function are left untouched via a return-address check on the specific call site.

Logs exception details and a symbolicated stack trace to ModLoader.log and shows a local MessageBox instead. Adds a debug-only crash test button to the ModLoader window.