### PR TITLE
Gate crash_reporter.cpp/.h behind MODLOADER_CLIENT_BUILD

### DIFF
--- a/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.cpp
+++ b/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#ifdef MODLOADER_CLIENT_BUILD
 #include "crash_reporter.h"
 #include "logging/logger.h"
 #include "memory_scanner/scanner.h"
@@ -201,3 +202,5 @@ namespace Hooks::CrashReporter
 		return reinterpret_cast<uintptr_t>(g_original);
 	}
 }
+
+#endif // MODLOADER_CLIENT_BUILD

--- a/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.h
+++ b/StarRupture-ModLoader-Core/hooks/game/crash_reporter/crash_reporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef MODLOADER_CLIENT_BUILD
+
 #include "../../hooks_common.h"
 #include <cstdint>
 
@@ -42,3 +44,5 @@ namespace Hooks::CrashReporter
 	// Cast to: int64_t(__fastcall*)(void* InContext, void* ExceptionInfo, int32_t ReportUI)
 	uintptr_t GetOriginalPtr();
 }
+
+#endif // MODLOADER_CLIENT_BUILD


### PR DESCRIPTION
The .cpp was unconditionally in the vcxproj ItemGroup and referenced client-only scan patterns directly, breaking non-client builds. Wrap the whole file like hud_post_render.cpp does, since the code has no meaning on a dedicated server anyway.