### PR TITLE
Add ImDrawList direct-drawing API to IModLoaderImGui

### DIFF
--- a/StarRupture-ModLoader-Core/UI/imgui_backend.cpp
+++ b/StarRupture-ModLoader-Core/UI/imgui_backend.cpp
@@ -1540,6 +1540,90 @@ namespace ImGuiWrappers
 	static void SetClipboardText(const char* t) { ImGui::SetClipboardText(t); }
 	static const char* GetStyleColorName(int idx) { return ImGui::GetStyleColorName((ImGuiCol)idx); }
 
+	// -----------------------------------------------------------------------
+	// v48 -- direct drawing (ImDrawList)
+	// -----------------------------------------------------------------------
+	static PluginDrawList GetWindowDrawList() { return (PluginDrawList)ImGui::GetWindowDrawList(); }
+	static PluginDrawList GetBackgroundDrawList() { return (PluginDrawList)ImGui::GetBackgroundDrawList(); }
+	static PluginDrawList GetForegroundDrawList() { return (PluginDrawList)ImGui::GetForegroundDrawList(); }
+
+	static void DL_AddLine(PluginDrawList dl, float x1, float y1, float x2, float y2, unsigned int col, float thickness)
+	{ ((ImDrawList*)dl)->AddLine(ImVec2(x1, y1), ImVec2(x2, y2), col, thickness); }
+	static void DL_AddRect(PluginDrawList dl, float minx, float miny, float maxx, float maxy, unsigned int col, float rounding, int flags, float thickness)
+	{ ((ImDrawList*)dl)->AddRect(ImVec2(minx, miny), ImVec2(maxx, maxy), col, rounding, thickness, (ImDrawFlags)flags); }
+	static void DL_AddRectFilled(PluginDrawList dl, float minx, float miny, float maxx, float maxy, unsigned int col, float rounding, int flags)
+	{ ((ImDrawList*)dl)->AddRectFilled(ImVec2(minx, miny), ImVec2(maxx, maxy), col, rounding, (ImDrawFlags)flags); }
+	static void DL_AddRectFilledMultiColor(PluginDrawList dl, float minx, float miny, float maxx, float maxy, unsigned int cul, unsigned int cur, unsigned int cbr, unsigned int cbl)
+	{ ((ImDrawList*)dl)->AddRectFilledMultiColor(ImVec2(minx, miny), ImVec2(maxx, maxy), cul, cur, cbr, cbl); }
+	static void DL_AddQuad(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col, float thickness)
+	{ ((ImDrawList*)dl)->AddQuad(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), ImVec2(x4, y4), col, thickness); }
+	static void DL_AddQuadFilled(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col)
+	{ ((ImDrawList*)dl)->AddQuadFilled(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), ImVec2(x4, y4), col); }
+	static void DL_AddTriangle(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col, float thickness)
+	{ ((ImDrawList*)dl)->AddTriangle(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), col, thickness); }
+	static void DL_AddTriangleFilled(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col)
+	{ ((ImDrawList*)dl)->AddTriangleFilled(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), col); }
+	static void DL_AddCircle(PluginDrawList dl, float cx, float cy, float radius, unsigned int col, int num_segments, float thickness)
+	{ ((ImDrawList*)dl)->AddCircle(ImVec2(cx, cy), radius, col, num_segments, thickness); }
+	static void DL_AddCircleFilled(PluginDrawList dl, float cx, float cy, float radius, unsigned int col, int num_segments)
+	{ ((ImDrawList*)dl)->AddCircleFilled(ImVec2(cx, cy), radius, col, num_segments); }
+	static void DL_AddNgon(PluginDrawList dl, float cx, float cy, float radius, unsigned int col, int num_segments, float thickness)
+	{ ((ImDrawList*)dl)->AddNgon(ImVec2(cx, cy), radius, col, num_segments, thickness); }
+	static void DL_AddNgonFilled(PluginDrawList dl, float cx, float cy, float radius, unsigned int col, int num_segments)
+	{ ((ImDrawList*)dl)->AddNgonFilled(ImVec2(cx, cy), radius, col, num_segments); }
+	static void DL_AddEllipse(PluginDrawList dl, float cx, float cy, float rx, float ry, unsigned int col, float rot, int num_segments, float thickness)
+	{ ((ImDrawList*)dl)->AddEllipse(ImVec2(cx, cy), ImVec2(rx, ry), col, rot, num_segments, thickness); }
+	static void DL_AddEllipseFilled(PluginDrawList dl, float cx, float cy, float rx, float ry, unsigned int col, float rot, int num_segments)
+	{ ((ImDrawList*)dl)->AddEllipseFilled(ImVec2(cx, cy), ImVec2(rx, ry), col, rot, num_segments); }
+	static void DL_AddText(PluginDrawList dl, float x, float y, unsigned int col, const char* text)
+	{ ((ImDrawList*)dl)->AddText(ImVec2(x, y), col, text); }
+	static void DL_AddTextSized(PluginDrawList dl, float font_size, float x, float y, unsigned int col, const char* text)
+	{ ((ImDrawList*)dl)->AddText(ImGui::GetFont(), font_size, ImVec2(x, y), col, text); }
+
+	// points_xy is a flat (x,y,x,y,...) array; ImVec2 is POD {float x, float y},
+	// so it can be reinterpreted directly without a copy.
+	static void DL_AddPolyline(PluginDrawList dl, const float* xy, int count, unsigned int col, int flags, float thickness)
+	{
+		if (!xy || count <= 0) return;
+		((ImDrawList*)dl)->AddPolyline((const ImVec2*)xy, count, col, thickness, (ImDrawFlags)flags);
+	}
+	static void DL_AddConvexPolyFilled(PluginDrawList dl, const float* xy, int count, unsigned int col)
+	{
+		if (!xy || count <= 0) return;
+		((ImDrawList*)dl)->AddConvexPolyFilled((const ImVec2*)xy, count, col);
+	}
+	static void DL_AddBezierCubic(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col, float thickness, int num_segments)
+	{ ((ImDrawList*)dl)->AddBezierCubic(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), ImVec2(x4, y4), col, thickness, num_segments); }
+	static void DL_AddBezierQuadratic(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col, float thickness, int num_segments)
+	{ ((ImDrawList*)dl)->AddBezierQuadratic(ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), col, thickness, num_segments); }
+
+	static void DL_PathClear(PluginDrawList dl) { ((ImDrawList*)dl)->PathClear(); }
+	static void DL_PathLineTo(PluginDrawList dl, float x, float y) { ((ImDrawList*)dl)->PathLineTo(ImVec2(x, y)); }
+	static void DL_PathArcTo(PluginDrawList dl, float cx, float cy, float radius, float amin, float amax, int num_segments)
+	{ ((ImDrawList*)dl)->PathArcTo(ImVec2(cx, cy), radius, amin, amax, num_segments); }
+	static void DL_PathArcToFast(PluginDrawList dl, float cx, float cy, float radius, int amin12, int amax12)
+	{ ((ImDrawList*)dl)->PathArcToFast(ImVec2(cx, cy), radius, amin12, amax12); }
+	static void DL_PathEllipticalArcTo(PluginDrawList dl, float cx, float cy, float rx, float ry, float rot, float amin, float amax, int num_segments)
+	{ ((ImDrawList*)dl)->PathEllipticalArcTo(ImVec2(cx, cy), ImVec2(rx, ry), rot, amin, amax, num_segments); }
+	static void DL_PathBezierCubicCurveTo(PluginDrawList dl, float x2, float y2, float x3, float y3, float x4, float y4, int num_segments)
+	{ ((ImDrawList*)dl)->PathBezierCubicCurveTo(ImVec2(x2, y2), ImVec2(x3, y3), ImVec2(x4, y4), num_segments); }
+	static void DL_PathBezierQuadraticCurveTo(PluginDrawList dl, float x2, float y2, float x3, float y3, int num_segments)
+	{ ((ImDrawList*)dl)->PathBezierQuadraticCurveTo(ImVec2(x2, y2), ImVec2(x3, y3), num_segments); }
+	static void DL_PathRect(PluginDrawList dl, float minx, float miny, float maxx, float maxy, float rounding, int flags)
+	{ ((ImDrawList*)dl)->PathRect(ImVec2(minx, miny), ImVec2(maxx, maxy), rounding, (ImDrawFlags)flags); }
+	static void DL_PathFillConvex(PluginDrawList dl, unsigned int col) { ((ImDrawList*)dl)->PathFillConvex(col); }
+	static void DL_PathStroke(PluginDrawList dl, unsigned int col, int flags, float thickness)
+	{ ((ImDrawList*)dl)->PathStroke(col, thickness, (ImDrawFlags)flags); }
+
+	static void DL_PushClipRect(PluginDrawList dl, float minx, float miny, float maxx, float maxy, bool intersect)
+	{ ((ImDrawList*)dl)->PushClipRect(ImVec2(minx, miny), ImVec2(maxx, maxy), intersect); }
+	static void DL_PushClipRectFullScreen(PluginDrawList dl) { ((ImDrawList*)dl)->PushClipRectFullScreen(); }
+	static void DL_PopClipRect(PluginDrawList dl) { ((ImDrawList*)dl)->PopClipRect(); }
+	static void DL_GetClipRectMin(PluginDrawList dl, float* ox, float* oy)
+	{ ImVec2 v = ((ImDrawList*)dl)->GetClipRectMin(); if (ox) *ox = v.x; if (oy) *oy = v.y; }
+	static void DL_GetClipRectMax(PluginDrawList dl, float* ox, float* oy)
+	{ ImVec2 v = ((ImDrawList*)dl)->GetClipRectMax(); if (ox) *ox = v.x; if (oy) *oy = v.y; }
+
 	// v35 child windows (original placement)
 	static bool BeginChild(const char* id, float sx, float sy, bool border)
 	{
@@ -2497,6 +2581,32 @@ static int TextureGetCapacity()
 	return MAX_PLUGIN_TEXTURES;
 }
 
+// ---------------------------------------------------------------------------
+// v48 -- ImDrawList Image* wrappers (need ValidateHandle, defined above)
+// ---------------------------------------------------------------------------
+static void DL_AddImage(PluginDrawList dl, PluginTextureHandle tex, float minx, float miny, float maxx, float maxy, float u0, float v0, float u1, float v1, unsigned int col)
+{
+	PluginTextureRecord* rec = ValidateHandle(tex);
+	if (!rec) return;
+	((ImDrawList*)dl)->AddImage((ImTextureID)rec->gpuHandle.ptr, ImVec2(minx, miny), ImVec2(maxx, maxy), ImVec2(u0, v0), ImVec2(u1, v1), col);
+}
+
+static void DL_AddImageQuad(PluginDrawList dl, PluginTextureHandle tex, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float u1, float v1, float u2, float v2, float u3, float v3, float u4, float v4, unsigned int col)
+{
+	PluginTextureRecord* rec = ValidateHandle(tex);
+	if (!rec) return;
+	((ImDrawList*)dl)->AddImageQuad((ImTextureID)rec->gpuHandle.ptr,
+		ImVec2(x1, y1), ImVec2(x2, y2), ImVec2(x3, y3), ImVec2(x4, y4),
+		ImVec2(u1, v1), ImVec2(u2, v2), ImVec2(u3, v3), ImVec2(u4, v4), col);
+}
+
+static void DL_AddImageRounded(PluginDrawList dl, PluginTextureHandle tex, float minx, float miny, float maxx, float maxy, float u0, float v0, float u1, float v1, unsigned int col, float rounding, int flags)
+{
+	PluginTextureRecord* rec = ValidateHandle(tex);
+	if (!rec) return;
+	((ImDrawList*)dl)->AddImageRounded((ImTextureID)rec->gpuHandle.ptr, ImVec2(minx, miny), ImVec2(maxx, maxy), ImVec2(u0, v0), ImVec2(u1, v1), col, rounding, (ImDrawFlags)flags);
+}
+
 static void PopulateTextureAPI()
 {
 	g_textureAPI.LoadFromFile        = TextureLoadFromFile;
@@ -2729,6 +2839,49 @@ static void PopulateImGuiAPI()
 	g_imguiAPI.GetClipboardText = ImGuiWrappers::GetClipboardText;
 	g_imguiAPI.SetClipboardText = ImGuiWrappers::SetClipboardText;
 	g_imguiAPI.GetStyleColorName = ImGuiWrappers::GetStyleColorName;
+
+	// v48 -- direct drawing (ImDrawList)
+	g_imguiAPI.GetWindowDrawList = ImGuiWrappers::GetWindowDrawList;
+	g_imguiAPI.GetBackgroundDrawList = ImGuiWrappers::GetBackgroundDrawList;
+	g_imguiAPI.GetForegroundDrawList = ImGuiWrappers::GetForegroundDrawList;
+	g_imguiAPI.DL_AddLine = ImGuiWrappers::DL_AddLine;
+	g_imguiAPI.DL_AddRect = ImGuiWrappers::DL_AddRect;
+	g_imguiAPI.DL_AddRectFilled = ImGuiWrappers::DL_AddRectFilled;
+	g_imguiAPI.DL_AddRectFilledMultiColor = ImGuiWrappers::DL_AddRectFilledMultiColor;
+	g_imguiAPI.DL_AddQuad = ImGuiWrappers::DL_AddQuad;
+	g_imguiAPI.DL_AddQuadFilled = ImGuiWrappers::DL_AddQuadFilled;
+	g_imguiAPI.DL_AddTriangle = ImGuiWrappers::DL_AddTriangle;
+	g_imguiAPI.DL_AddTriangleFilled = ImGuiWrappers::DL_AddTriangleFilled;
+	g_imguiAPI.DL_AddCircle = ImGuiWrappers::DL_AddCircle;
+	g_imguiAPI.DL_AddCircleFilled = ImGuiWrappers::DL_AddCircleFilled;
+	g_imguiAPI.DL_AddNgon = ImGuiWrappers::DL_AddNgon;
+	g_imguiAPI.DL_AddNgonFilled = ImGuiWrappers::DL_AddNgonFilled;
+	g_imguiAPI.DL_AddEllipse = ImGuiWrappers::DL_AddEllipse;
+	g_imguiAPI.DL_AddEllipseFilled = ImGuiWrappers::DL_AddEllipseFilled;
+	g_imguiAPI.DL_AddText = ImGuiWrappers::DL_AddText;
+	g_imguiAPI.DL_AddTextSized = ImGuiWrappers::DL_AddTextSized;
+	g_imguiAPI.DL_AddPolyline = ImGuiWrappers::DL_AddPolyline;
+	g_imguiAPI.DL_AddConvexPolyFilled = ImGuiWrappers::DL_AddConvexPolyFilled;
+	g_imguiAPI.DL_AddBezierCubic = ImGuiWrappers::DL_AddBezierCubic;
+	g_imguiAPI.DL_AddBezierQuadratic = ImGuiWrappers::DL_AddBezierQuadratic;
+	g_imguiAPI.DL_AddImage = DL_AddImage;
+	g_imguiAPI.DL_AddImageQuad = DL_AddImageQuad;
+	g_imguiAPI.DL_AddImageRounded = DL_AddImageRounded;
+	g_imguiAPI.DL_PathClear = ImGuiWrappers::DL_PathClear;
+	g_imguiAPI.DL_PathLineTo = ImGuiWrappers::DL_PathLineTo;
+	g_imguiAPI.DL_PathArcTo = ImGuiWrappers::DL_PathArcTo;
+	g_imguiAPI.DL_PathArcToFast = ImGuiWrappers::DL_PathArcToFast;
+	g_imguiAPI.DL_PathEllipticalArcTo = ImGuiWrappers::DL_PathEllipticalArcTo;
+	g_imguiAPI.DL_PathBezierCubicCurveTo = ImGuiWrappers::DL_PathBezierCubicCurveTo;
+	g_imguiAPI.DL_PathBezierQuadraticCurveTo = ImGuiWrappers::DL_PathBezierQuadraticCurveTo;
+	g_imguiAPI.DL_PathRect = ImGuiWrappers::DL_PathRect;
+	g_imguiAPI.DL_PathFillConvex = ImGuiWrappers::DL_PathFillConvex;
+	g_imguiAPI.DL_PathStroke = ImGuiWrappers::DL_PathStroke;
+	g_imguiAPI.DL_PushClipRect = ImGuiWrappers::DL_PushClipRect;
+	g_imguiAPI.DL_PushClipRectFullScreen = ImGuiWrappers::DL_PushClipRectFullScreen;
+	g_imguiAPI.DL_PopClipRect = ImGuiWrappers::DL_PopClipRect;
+	g_imguiAPI.DL_GetClipRectMin = ImGuiWrappers::DL_GetClipRectMin;
+	g_imguiAPI.DL_GetClipRectMax = ImGuiWrappers::DL_GetClipRectMax;
 }
 
 // ---------------------------------------------------------------------------

--- a/StarRupture-ModLoader-Core/plugins/plugin_interface.h
+++ b/StarRupture-ModLoader-Core/plugins/plugin_interface.h
@@ -185,10 +185,25 @@
 //      metadata to look up by name. v47 is unreleased, so this lands in the
 //      same version as IPluginObjectWalker/IPluginDelegateHook above.
 //      Appended at the end of IPluginHooks. MIN remains 46.
+// v48: Added ImDrawList direct-drawing access to IModLoaderImGui (appended at
+//      the end of the struct, so existing v34+ plugins keep working unchanged).
+//      GetWindowDrawList/GetBackgroundDrawList/GetForegroundDrawList return an
+//      opaque PluginDrawList (== ImDrawList*) handle valid for the current
+//      frame only -- do not cache it across frames. Covers shape primitives
+//      (Line, Rect(Filled), RectFilledMultiColor, Quad(Filled),
+//      Triangle(Filled), Circle(Filled), Ngon(Filled), Ellipse(Filled),
+//      Text/TextSized, Polyline, ConvexPolyFilled, BezierCubic/Quadratic),
+//      images via existing PluginTextureHandle (Image, ImageQuad,
+//      ImageRounded), the stateful Path* builder API (PathClear/LineTo/ArcTo/
+//      ArcToFast/EllipticalArcTo/BezierCubicCurveTo/BezierQuadraticCurveTo/
+//      Rect/FillConvex/Stroke), and draw-list-local clip rect stack
+//      (PushClipRect/PushClipRectFullScreen/PopClipRect/GetClipRectMin/Max).
+//      Colors are packed 0xAABBGGRR ImU32 -- build them with the existing
+//      GetColorU32FromVec4/GetColorU32FromCol helpers. MIN remains 46.
 
 #define PLUGIN_INTERFACE_VERSION_MIN 46
-#define PLUGIN_INTERFACE_VERSION_MAX 47
-#define PLUGIN_INTERFACE_VERSION 47
+#define PLUGIN_INTERFACE_VERSION_MAX 48
+#define PLUGIN_INTERFACE_VERSION 48
 
 enum class PluginLogLevel { Trace = 0, Debug = 1, Info = 2, Warn = 3, Error = 4 };
 enum class ConfigValueType { String, Integer, Float, Boolean, Keybind };
@@ -480,6 +495,32 @@ struct IPluginInputEvents
 	void (*UnregisterKeybindCombo)(EModKey key, EModKeyModifiers mods, EModKeyEvent event, PluginKeybindComboCallback callback);
 };
 
+// Opaque handle for a texture registered through IPluginImGuiTextures (v37).
+// Forward-declared here (fully defined again, identically, near
+// IPluginImGuiTextures below) so IModLoaderImGui's draw-list Image* functions
+// can take one without reordering the whole header.
+typedef void* PluginTextureHandle;
+
+// Opaque handle for an ImDrawList*, returned by GetWindowDrawList /
+// GetBackgroundDrawList / GetForegroundDrawList (v48). Only valid for the
+// duration of the current frame's render callback -- do not cache across
+// frames.
+typedef void* PluginDrawList;
+
+// Flags for the rounding-corner parameters below. Mirrors ImDrawFlags.
+#define PluginDrawFlags_None                     0
+#define PluginDrawFlags_Closed                    (1 << 0)
+#define PluginDrawFlags_RoundCornersTopLeft        (1 << 4)
+#define PluginDrawFlags_RoundCornersTopRight        (1 << 5)
+#define PluginDrawFlags_RoundCornersBottomLeft      (1 << 6)
+#define PluginDrawFlags_RoundCornersBottomRight     (1 << 7)
+#define PluginDrawFlags_RoundCornersNone           (1 << 8)
+#define PluginDrawFlags_RoundCornersTop            (PluginDrawFlags_RoundCornersTopLeft | PluginDrawFlags_RoundCornersTopRight)
+#define PluginDrawFlags_RoundCornersBottom         (PluginDrawFlags_RoundCornersBottomLeft | PluginDrawFlags_RoundCornersBottomRight)
+#define PluginDrawFlags_RoundCornersLeft           (PluginDrawFlags_RoundCornersBottomLeft | PluginDrawFlags_RoundCornersTopLeft)
+#define PluginDrawFlags_RoundCornersRight          (PluginDrawFlags_RoundCornersBottomRight | PluginDrawFlags_RoundCornersTopRight)
+#define PluginDrawFlags_RoundCornersAll            (PluginDrawFlags_RoundCornersTopLeft | PluginDrawFlags_RoundCornersTopRight | PluginDrawFlags_RoundCornersBottomLeft | PluginDrawFlags_RoundCornersBottomRight)
+
 // ---------------------------------------------------------------------------
 // UI (v15–v16, client only; extended v24)
 // ---------------------------------------------------------------------------
@@ -763,6 +804,69 @@ struct IModLoaderImGui
 	const char*   (*GetClipboardText)();
 	void          (*SetClipboardText)(const char* text);
 	const char*   (*GetStyleColorName)(int idx);
+
+	// -------------------------------------------------------------------------
+	// v48: Direct drawing (ImDrawList)
+	// -------------------------------------------------------------------------
+	// Acquire a draw list. Only valid for the current frame's render callback --
+	// do not cache the returned handle across frames.
+	PluginDrawList (*GetWindowDrawList)();
+	PluginDrawList (*GetBackgroundDrawList)();
+	PluginDrawList (*GetForegroundDrawList)();
+
+	// Shape primitives. Colors are packed 0xAABBGGRR ImU32 (see
+	// GetColorU32FromVec4 / GetColorU32FromCol above).
+	void (*DL_AddLine)(PluginDrawList dl, float x1, float y1, float x2, float y2, unsigned int col, float thickness);
+	void (*DL_AddRect)(PluginDrawList dl, float min_x, float min_y, float max_x, float max_y, unsigned int col, float rounding, int flags, float thickness);
+	void (*DL_AddRectFilled)(PluginDrawList dl, float min_x, float min_y, float max_x, float max_y, unsigned int col, float rounding, int flags);
+	void (*DL_AddRectFilledMultiColor)(PluginDrawList dl, float min_x, float min_y, float max_x, float max_y, unsigned int col_upr_left, unsigned int col_upr_right, unsigned int col_bot_right, unsigned int col_bot_left);
+	void (*DL_AddQuad)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col, float thickness);
+	void (*DL_AddQuadFilled)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col);
+	void (*DL_AddTriangle)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col, float thickness);
+	void (*DL_AddTriangleFilled)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col);
+	void (*DL_AddCircle)(PluginDrawList dl, float center_x, float center_y, float radius, unsigned int col, int num_segments, float thickness);
+	void (*DL_AddCircleFilled)(PluginDrawList dl, float center_x, float center_y, float radius, unsigned int col, int num_segments);
+	void (*DL_AddNgon)(PluginDrawList dl, float center_x, float center_y, float radius, unsigned int col, int num_segments, float thickness);
+	void (*DL_AddNgonFilled)(PluginDrawList dl, float center_x, float center_y, float radius, unsigned int col, int num_segments);
+	void (*DL_AddEllipse)(PluginDrawList dl, float center_x, float center_y, float radius_x, float radius_y, unsigned int col, float rot, int num_segments, float thickness);
+	void (*DL_AddEllipseFilled)(PluginDrawList dl, float center_x, float center_y, float radius_x, float radius_y, unsigned int col, float rot, int num_segments);
+
+	// Text drawn directly onto the draw list (bypasses layout/cursor).
+	void (*DL_AddText)(PluginDrawList dl, float x, float y, unsigned int col, const char* text);
+	void (*DL_AddTextSized)(PluginDrawList dl, float font_size, float x, float y, unsigned int col, const char* text);
+
+	// points_xy is a flat array of (x,y) pairs, length == point_count * 2.
+	void (*DL_AddPolyline)(PluginDrawList dl, const float* points_xy, int point_count, unsigned int col, int flags, float thickness);
+	void (*DL_AddConvexPolyFilled)(PluginDrawList dl, const float* points_xy, int point_count, unsigned int col);
+	void (*DL_AddBezierCubic)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, unsigned int col, float thickness, int num_segments);
+	void (*DL_AddBezierQuadratic)(PluginDrawList dl, float x1, float y1, float x2, float y2, float x3, float y3, unsigned int col, float thickness, int num_segments);
+
+	// Images -- tex must be a handle obtained from IPluginImGuiTextures (hooks->ImGuiTextures).
+	void (*DL_AddImage)(PluginDrawList dl, PluginTextureHandle tex, float min_x, float min_y, float max_x, float max_y, float uv_min_x, float uv_min_y, float uv_max_x, float uv_max_y, unsigned int col);
+	void (*DL_AddImageQuad)(PluginDrawList dl, PluginTextureHandle tex, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4, float u1, float v1, float u2, float v2, float u3, float v3, float u4, float v4, unsigned int col);
+	void (*DL_AddImageRounded)(PluginDrawList dl, PluginTextureHandle tex, float min_x, float min_y, float max_x, float max_y, float uv_min_x, float uv_min_y, float uv_max_x, float uv_max_y, unsigned int col, float rounding, int flags);
+
+	// Stateful path builder: accumulate points with PathLineTo/PathArcTo/etc,
+	// then emit a primitive with PathStroke or PathFillConvex. PathClear resets
+	// the accumulated point list without emitting anything.
+	void (*DL_PathClear)(PluginDrawList dl);
+	void (*DL_PathLineTo)(PluginDrawList dl, float x, float y);
+	void (*DL_PathArcTo)(PluginDrawList dl, float center_x, float center_y, float radius, float a_min, float a_max, int num_segments);
+	void (*DL_PathArcToFast)(PluginDrawList dl, float center_x, float center_y, float radius, int a_min_of_12, int a_max_of_12);
+	void (*DL_PathEllipticalArcTo)(PluginDrawList dl, float center_x, float center_y, float radius_x, float radius_y, float rot, float a_min, float a_max, int num_segments);
+	void (*DL_PathBezierCubicCurveTo)(PluginDrawList dl, float x2, float y2, float x3, float y3, float x4, float y4, int num_segments);
+	void (*DL_PathBezierQuadraticCurveTo)(PluginDrawList dl, float x2, float y2, float x3, float y3, int num_segments);
+	void (*DL_PathRect)(PluginDrawList dl, float min_x, float min_y, float max_x, float max_y, float rounding, int flags);
+	void (*DL_PathFillConvex)(PluginDrawList dl, unsigned int col);
+	void (*DL_PathStroke)(PluginDrawList dl, unsigned int col, int flags, float thickness);
+
+	// Draw-list-local clip rect stack (separate from the window-level clip
+	// stack managed by PushClipRect/PopClipRect above).
+	void (*DL_PushClipRect)(PluginDrawList dl, float min_x, float min_y, float max_x, float max_y, bool intersect_current);
+	void (*DL_PushClipRectFullScreen)(PluginDrawList dl);
+	void (*DL_PopClipRect)(PluginDrawList dl);
+	void (*DL_GetClipRectMin)(PluginDrawList dl, float* out_x, float* out_y);
+	void (*DL_GetClipRectMax)(PluginDrawList dl, float* out_x, float* out_y);
 };
 
 typedef void (*PluginImGuiRenderCallback)(IModLoaderImGui* imgui);


### PR DESCRIPTION
Exposes GetWindowDrawList/GetBackgroundDrawList/GetForegroundDrawList plus shape primitives, text, polylines/beziers, images, the stateful path builder, and draw-list-local clip rects, so plugins can do raw ImGui drawing instead of only widget calls. Interface version bumped to 48 (additive, MIN stays 46).