### PR TITLE
Scope plugin config-change notifications and fire them live

### DIFF
--- a/ImGui_Dev.md
+++ b/ImGui_Dev.md
@@ -236,9 +236,14 @@ player's chosen position persists between sessions.
 ## Config-Change Notifications
 
 If you want to be notified whenever the user edits a value in your plugin's config via the
-ModLoader UI, register a `PluginConfigChangedCallback`:
+ModLoader UI, register a `PluginConfigChangedCallback`. Pass the `self` pointer your `PluginInit`
+received -- the modloader uses it to scope the callback to your plugin's own config file, so you
+are never notified about another plugin's config changes. `PluginShutdown` does not receive
+`self`, so cache it in a static during `PluginInit`:
 
 ```cpp
+static IPluginSelf* g_self = nullptr;
+
 static void OnConfigChanged(const char* section, const char* key, const char* newValue)
 {
     if (strcmp(section, "General") == 0 && strcmp(key, "Speed") == 0)
@@ -248,12 +253,13 @@ static void OnConfigChanged(const char* section, const char* key, const char* ne
 }
 
 // In PluginInit:
+g_self = self;
 if (hooks->UI)
-    hooks->UI->RegisterOnConfigChanged(OnConfigChanged);
+    hooks->UI->RegisterOnConfigChanged(self, OnConfigChanged);
 
 // In PluginShutdown:
 if (hooks->UI)
-    hooks->UI->UnregisterOnConfigChanged(OnConfigChanged);
+    hooks->UI->UnregisterOnConfigChanged(g_self, OnConfigChanged);
 ```
 
 `newValue` is the raw string that was written to the INI file (e.g. `"true"`, `"42"`, `"3.14"`).

--- a/StarRupture-ModLoader-Core/UI/modloader_window.cpp
+++ b/StarRupture-ModLoader-Core/UI/modloader_window.cpp
@@ -133,7 +133,21 @@ namespace UI::ModLoaderWindow
         }
     }
 
-    // Write a changed value back to disk and fire config-change notifications.
+    // Fire config-change notifications for the in-memory value immediately.
+    // Call this at the point kv.value actually changes, for every config
+    // type -- not just while a slider is mid-drag -- so plugins see the
+    // live value right away instead of waiting for CommitConfigChange to
+    // flush it to disk. Deliberately does no disk I/O so it is cheap enough
+    // to call every frame a value changes (e.g. once per drag frame).
+    static void NotifyConfigChangedLive(const char* pluginName, const ConfigKV& kv)
+    {
+        UI::PluginPanelRegistry::FireConfigChanged(pluginName, kv.section, kv.key, kv.value);
+    }
+
+    // Write a changed value back to disk. Does NOT fire config-change
+    // notifications -- callers must call NotifyConfigChangedLive themselves
+    // at the point the value changes (this keeps notification timing
+    // decoupled from, and not gated on, the disk write).
     static void CommitConfigChange(const char* pluginName, ConfigKV& kv,
                                    const char* oldValue = nullptr,
                                    const ConfigEntry* entry = nullptr)
@@ -167,8 +181,6 @@ namespace UI::ModLoaderWindow
 
             Hooks::Input::UpdateKeybindByName(pluginName, oldValue, kv.value);
         }
-
-        UI::PluginPanelRegistry::FireConfigChanged(kv.section, kv.key, kv.value);
     }
 
     // -----------------------------------------------------------------------
@@ -354,7 +366,10 @@ namespace UI::ModLoaderWindow
             if (hasRange)
             {
                 if (ImGui::SliderInt(id, &ival, (int)e->rangeMin, (int)e->rangeMax))
+                {
                     snprintf(kv.value, sizeof(kv.value), "%d", ival);
+                    NotifyConfigChangedLive(pluginName, kv);
+                }
                 if (ImGui::IsItemDeactivated())
                     CommitConfigChange(pluginName, kv);
             }
@@ -363,11 +378,13 @@ namespace UI::ModLoaderWindow
                 if (ImGui::InputInt(id, &ival, 1, 10))
                 {
                     snprintf(kv.value, sizeof(kv.value), "%d", ival);
+                    NotifyConfigChangedLive(pluginName, kv);
                     CommitConfigChange(pluginName, kv);
                 }
                 if (ImGui::IsItemDeactivatedAfterEdit())
                 {
                     snprintf(kv.value, sizeof(kv.value), "%d", ival);
+                    NotifyConfigChangedLive(pluginName, kv);
                     CommitConfigChange(pluginName, kv);
                 }
             }
@@ -380,7 +397,10 @@ namespace UI::ModLoaderWindow
             if (hasRange)
             {
                 if (ImGui::SliderFloat(id, &fval, e->rangeMin, e->rangeMax, "%.6f"))
+                {
                     FormatFloat(kv.value, sizeof(kv.value), fval);
+                    NotifyConfigChangedLive(pluginName, kv);
+                }
                 if (ImGui::IsItemDeactivated())
                     CommitConfigChange(pluginName, kv);
             }
@@ -389,11 +409,13 @@ namespace UI::ModLoaderWindow
                 if (ImGui::InputFloat(id, &fval, 0.0f, 0.0f, "%.6f"))
                 {
                     FormatFloat(kv.value, sizeof(kv.value), fval);
+                    NotifyConfigChangedLive(pluginName, kv);
                     CommitConfigChange(pluginName, kv);
                 }
                 if (ImGui::IsItemDeactivatedAfterEdit())
                 {
                     FormatFloat(kv.value, sizeof(kv.value), fval);
+                    NotifyConfigChangedLive(pluginName, kv);
                     CommitConfigChange(pluginName, kv);
                 }
             }
@@ -424,9 +446,15 @@ namespace UI::ModLoaderWindow
             // String or unknown schema entry: plain text input.
             if (ImGui::InputText(id, kv.value, sizeof(kv.value),
                                  ImGuiInputTextFlags_EnterReturnsTrue))
+            {
+                NotifyConfigChangedLive(pluginName, kv);
                 CommitConfigChange(pluginName, kv);
+            }
             if (ImGui::IsItemDeactivatedAfterEdit())
+            {
+                NotifyConfigChangedLive(pluginName, kv);
                 CommitConfigChange(pluginName, kv);
+            }
             widgetHovered = ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal);
         }
 
@@ -446,6 +474,7 @@ namespace UI::ModLoaderWindow
             if (UI::Theme::ToggleSwitch(lbl, &bval))
             {
                 strncpy_s(kv.value, bval ? "true" : "false", _TRUNCATE);
+                NotifyConfigChangedLive(pluginName, kv);
                 CommitConfigChange(pluginName, kv);
             }
             ImGui::SameLine();
@@ -492,6 +521,7 @@ namespace UI::ModLoaderWindow
             if (ImGui::SmallButton(resetId))
             {
                 strncpy_s(kv.value, e->defaultValue, _TRUNCATE);
+                NotifyConfigChangedLive(pluginName, kv);
                 CommitConfigChange(pluginName, kv);
             }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
@@ -597,6 +627,7 @@ namespace UI::ModLoaderWindow
                         // Find the schema entry so CommitConfigChange can trigger live-rebind.
                         const ConfigSchema* schema = ModLoaderLogger::GetPluginSchema(s_rebind.pluginName);
                         const ConfigEntry* schEntry = FindSchemaEntry(schema, kv.section, kv.key);
+                        NotifyConfigChangedLive(s_rebind.pluginName, kv);
                         CommitConfigChange(s_rebind.pluginName, kv, oldValue, schEntry);
                         break;
                     }

--- a/StarRupture-ModLoader-Core/UI/plugin_panel_registry.cpp
+++ b/StarRupture-ModLoader-Core/UI/plugin_panel_registry.cpp
@@ -5,6 +5,7 @@
 
 #include "imgui/imgui.h"
 #include "theme.h"
+#include "plugins/plugin_manager.h"
 #include <mutex>
 #include <list>
 #include <vector>
@@ -21,9 +22,20 @@ namespace UI::PluginPanelRegistry
         char pluginName[64];   // set at registration time via SetCurrentRegistrationPlugin
     };
 
+    // Config-change callbacks are tagged with the registering plugin's stable
+    // IPluginSelf* identity (same pointer passed to PluginInit -- see
+    // PluginManager::LoadedPlugin::self) so FireConfigChanged can notify only
+    // the plugin whose config actually changed, via pointer comparison rather
+    // than a plugin-supplied name string.
+    struct ConfigCallbackEntry
+    {
+        PluginConfigChangedCallback callback;
+        const IPluginSelf* self;
+    };
+
     static std::mutex s_mutex;
     static std::list<PanelEntry> s_panels;   // list: insertion never invalidates existing pointers
-    static std::vector<PluginConfigChangedCallback> s_configCallbacks;
+    static std::vector<ConfigCallbackEntry> s_configCallbacks;
     static std::vector<PluginPanelClosedCallback> s_panelClosedCallbacks;
     static std::set<void*> s_captureTokens;
     static char s_currentPlugin[64];   // set by plugin_manager before each PluginInit call
@@ -84,26 +96,41 @@ namespace UI::PluginPanelRegistry
         // Handle not found — caller passed a stale or invalid handle; ignore silently.
     }
 
-    void RegisterOnConfigChanged(PluginConfigChangedCallback callback)
+    void RegisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback)
     {
         if (!callback) return;
         std::lock_guard<std::mutex> lock(s_mutex);
-        s_configCallbacks.push_back(callback);
+        ConfigCallbackEntry entry = {};
+        entry.callback = callback;
+        entry.self     = self;
+        s_configCallbacks.push_back(entry);
     }
 
-    void UnregisterOnConfigChanged(PluginConfigChangedCallback callback)
+    void UnregisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback)
     {
         if (!callback) return;
         std::lock_guard<std::mutex> lock(s_mutex);
         s_configCallbacks.erase(
-            std::remove(s_configCallbacks.begin(), s_configCallbacks.end(), callback),
+            std::remove_if(s_configCallbacks.begin(), s_configCallbacks.end(),
+                           [&](const ConfigCallbackEntry& e) { return e.callback == callback && e.self == self; }),
             s_configCallbacks.end());
     }
 
-    void FireConfigChanged(const char* section, const char* key, const char* newValue)
+    void FireConfigChanged(const char* pluginName, const char* section, const char* key, const char* newValue)
     {
-        std::lock_guard<std::mutex> lock(s_mutex);
-        for (auto cb : s_configCallbacks)
+        // Resolve the changed config's owning plugin to its stable self pointer
+        // once, then filter callbacks by pointer identity instead of a string
+        // compare -- also sidesteps any case-sensitivity mismatch entirely.
+        const IPluginSelf* changedSelf = pluginName ? PluginManager::GetSelfForPlugin(pluginName) : nullptr;
+
+        std::vector<PluginConfigChangedCallback> toCall;
+        {
+            std::lock_guard<std::mutex> lock(s_mutex);
+            for (auto& e : s_configCallbacks)
+                if (changedSelf && e.self == changedSelf)
+                    toCall.push_back(e.callback);
+        }
+        for (auto cb : toCall)
             cb(section, key, newValue);
     }
 

--- a/StarRupture-ModLoader-Core/UI/plugin_panel_registry.h
+++ b/StarRupture-ModLoader-Core/UI/plugin_panel_registry.h
@@ -26,9 +26,12 @@ namespace UI::PluginPanelRegistry
     // Remove a panel using the handle returned by RegisterPanel.
     void UnregisterPanel(PanelHandle handle);
 
-    // Register/unregister a config-change notification callback.
-    void RegisterOnConfigChanged(PluginConfigChangedCallback callback);
-    void UnregisterOnConfigChanged(PluginConfigChangedCallback callback);
+    // Register/unregister a config-change notification callback. self is the
+    // registering plugin's IPluginSelf* (same pointer passed to PluginInit) --
+    // FireConfigChanged only invokes callbacks whose self matches the plugin
+    // whose config actually changed.
+    void RegisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback);
+    void UnregisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback);
 
     // Open or close a panel using the handle returned by RegisterPanel.
     void SetPanelOpen(PanelHandle handle);
@@ -54,7 +57,9 @@ namespace UI::PluginPanelRegistry
     bool AnyPanelOpen();
 
     // Called by modloader_window to fire config-change notifications.
-    void FireConfigChanged(const char* section, const char* key, const char* newValue);
+    // pluginName is the plugin that owns the changed config file -- only
+    // callbacks registered by that plugin are invoked.
+    void FireConfigChanged(const char* pluginName, const char* section, const char* key, const char* newValue);
 
     // Renders "Open" buttons for panels belonging to pluginName (null = all).
     // Call from inside an ImGui window; handles Begin/End for each panel window.

--- a/StarRupture-ModLoader-Core/hooks/hooks_interface.cpp
+++ b/StarRupture-ModLoader-Core/hooks/hooks_interface.cpp
@@ -1141,20 +1141,20 @@ namespace ModLoaderLogger
 		UI::PluginPanelRegistry::UnregisterPanel(handle);
 	}
 
-	static void HooksRegisterOnConfigChanged(PluginConfigChangedCallback callback)
+	static void HooksRegisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback)
 	{
 		if (!callback)
 		{
 			LogWarn(L"[HooksInterface] RegisterOnConfigChanged: null callback");
 			return;
 		}
-		UI::PluginPanelRegistry::RegisterOnConfigChanged(callback);
+		UI::PluginPanelRegistry::RegisterOnConfigChanged(self, callback);
 	}
 
-	static void HooksUnregisterOnConfigChanged(PluginConfigChangedCallback callback)
+	static void HooksUnregisterOnConfigChanged(const IPluginSelf* self, PluginConfigChangedCallback callback)
 	{
 		if (!callback) return;
-		UI::PluginPanelRegistry::UnregisterOnConfigChanged(callback);
+		UI::PluginPanelRegistry::UnregisterOnConfigChanged(self, callback);
 	}
 
 	static void HooksSetPanelOpen(PanelHandle handle)

--- a/StarRupture-ModLoader-Core/plugins/plugin_interface.h
+++ b/StarRupture-ModLoader-Core/plugins/plugin_interface.h
@@ -200,10 +200,19 @@
 //      (PushClipRect/PushClipRectFullScreen/PopClipRect/GetClipRectMin/Max).
 //      Colors are packed 0xAABBGGRR ImU32 -- build them with the existing
 //      GetColorU32FromVec4/GetColorU32FromCol helpers. MIN remains 46.
+// v49: IPluginUIEvents::RegisterOnConfigChanged/UnregisterOnConfigChanged now
+//      take a leading `const IPluginSelf* self` parameter, matching the
+//      self-first convention already used by IPluginLogger/IPluginConfig.
+//      self is the same pointer received in PluginInit -- pass it straight
+//      through, no plugin-name string needed. The modloader uses it to scope
+//      FireConfigChanged so a plugin's callback only fires for edits to its
+//      own config file, instead of broadcasting every plugin's config
+//      changes to every registered listener. Breaking signature change:
+//      MIN bumped to 49.
 
-#define PLUGIN_INTERFACE_VERSION_MIN 46
-#define PLUGIN_INTERFACE_VERSION_MAX 48
-#define PLUGIN_INTERFACE_VERSION 48
+#define PLUGIN_INTERFACE_VERSION_MIN 49
+#define PLUGIN_INTERFACE_VERSION_MAX 49
+#define PLUGIN_INTERFACE_VERSION 49
 
 enum class PluginLogLevel { Trace = 0, Debug = 1, Info = 2, Warn = 3, Error = 4 };
 enum class ConfigValueType { String, Integer, Float, Boolean, Keybind };
@@ -1026,8 +1035,10 @@ struct IPluginUIEvents
 {
 	PanelHandle  (*RegisterPanel)(const PluginPanelDesc* desc);
 	void         (*UnregisterPanel)(PanelHandle handle);
-	void         (*RegisterOnConfigChanged)(PluginConfigChangedCallback callback);
-	void         (*UnregisterOnConfigChanged)(PluginConfigChangedCallback callback);
+	// v49: self scopes the callback to this plugin's own config file -- pass
+	// the same IPluginSelf* received in PluginInit.
+	void         (*RegisterOnConfigChanged)(const IPluginSelf* self, PluginConfigChangedCallback callback);
+	void         (*UnregisterOnConfigChanged)(const IPluginSelf* self, PluginConfigChangedCallback callback);
 	void         (*SetPanelOpen)(PanelHandle handle);
 	void       (*SetPanelClose)(PanelHandle handle);
 	WidgetHandle (*RegisterWidget)(const PluginWidgetDesc* desc);      // v16

--- a/StarRupture-ModLoader-Core/plugins/plugin_manager.cpp
+++ b/StarRupture-ModLoader-Core/plugins/plugin_manager.cpp
@@ -11,6 +11,7 @@
 #include "hooks/hooks_interface.h"
 #include <vector>
 #include <string>
+#include <cstring>
 #include <dbghelp.h>
 
 #pragma comment(lib, "dbghelp.lib")
@@ -678,6 +679,24 @@ namespace PluginManager
 		}
 		LeaveCriticalSection(&g_pluginLock);
 		return total;
+	}
+
+	const IPluginSelf* GetSelfForPlugin(const char* pluginName)
+	{
+		if (!pluginName) return nullptr;
+
+		EnterCriticalSection(&g_pluginLock);
+		const IPluginSelf* result = nullptr;
+		for (auto& p : g_loadedPlugins)
+		{
+			if (_stricmp(p->cachedName.c_str(), pluginName) == 0)
+			{
+				result = &p->self;
+				break;
+			}
+		}
+		LeaveCriticalSection(&g_pluginLock);
+		return result;
 	}
 
 	bool UnloadPlugin(int index)

--- a/StarRupture-ModLoader-Core/plugins/plugin_manager.h
+++ b/StarRupture-ModLoader-Core/plugins/plugin_manager.h
@@ -46,6 +46,13 @@ namespace PluginManager
     // Returns total record count (may exceed maxCount).
     int GetAllPluginStatuses(PluginStatus* out, int maxCount);
 
+    // Returns the stable IPluginSelf* for the named plugin record, or nullptr if
+    // no plugin with that name has ever been loaded this session. The pointer is
+    // valid for the lifetime of the process: plugin records are only ever freed
+    // as a batch in UnloadAllPlugins (full shutdown), never removed individually,
+    // so it stays stable across UnloadPlugin/ReloadPlugin cycles too.
+    const IPluginSelf* GetSelfForPlugin(const char* pluginName);
+
     // Unload the plugin at index: calls PluginShutdown + FreeLibrary.
     // The record is kept so it can be reloaded later.
     // Returns false if index is out of range or the plugin is already unloaded.


### PR DESCRIPTION
RegisterOnConfigChanged/UnregisterOnConfigChanged now take the plugin's IPluginSelf* (v49, MIN bumped -- breaking signature change) so a plugin's callback only fires for edits to its own config file instead of every plugin's config changes broadcasting to every listener. Uses the self pointer's stable identity rather than a plugin-supplied name string.

Also decouples notification from disk write: CommitConfigChange now only persists to the ini file, while a new NotifyConfigChangedLive fires the callback immediately at the point any config value changes in the modloader UI (slider drag, spinner, text field, checkbox, reset, keybind rebind) -- plugins see live edits instead of waiting for the value to be committed to disk.